### PR TITLE
🏃 Add Tilt provider file for integration with CAPM3 Tilt setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ hack/tools/bin/*
 examples/_out/*
 examples/provider-components/*-components.yaml
 out/*
+
+# Tilt files
+.tiltbuild/*
+tilt-settings.json
+tilt_config.json
+tilt.d/*

--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,0 +1,10 @@
+{
+    "name": "metal3-ipam",
+    "config": {
+        "kustomize_config": false,
+        "image": "quay.io/metal3-io/ip-address-manager",
+        "live_reload_deps": [
+            "api", "ipam", "config", "controllers", "go.mod", "go.sum", "main.go"
+        ]
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is for metal3-io/cluster-api-provider-metal3#132
