### PR TITLE
🏃 Update golang to latest to match version across all repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary on golang image
-FROM registry.hub.docker.com/library/golang:1.13 as builder
+FROM registry.hub.docker.com/library/golang:1.15.3 as builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ release-binary: $(RELEASE_DIR)
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace" \
 		-w /workspace \
-		golang:1.12.9 \
+		golang:1.15.3 \
 		go build -a -ldflags '-extldflags "-static"' \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/ip-address-manager
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go v0.57.0 // indirect

--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/golang:1.13
+FROM registry.hub.docker.com/library/golang:1.15.3
 
 WORKDIR /usr/local/kubebuilder
 COPY /hack/tools /usr/local/kubebuilder/

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -34,6 +34,6 @@ else
     --volume "${PWD}:/data:rw,z" \
     --entrypoint sh \
     --workdir /data \
-    registry.hub.docker.com/library/golang:1.13.7 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /data/hack/codegen.sh
 fi;

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.12.1
+  minimum_go_version=go1.15.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.12 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    registry.hub.docker.com/library/golang:1.13 \
+    registry.hub.docker.com/library/golang:1.15.3 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/govet.sh
 fi;

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api/hack/tools
 
-go 1.12
+go 1.15
 
 require (
 	github.com/golang/mock v1.4.3


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to avoid differences in go version across all repositories, this PR updates go to the latest in hack scripts. The motivation behind this is from [project-infra/pull/124](https://github.com/metal3-io/project-infra/pull/124).
