### PR TITLE
📖 Fix missing field in api documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,7 @@ The *spec* field contains the following :
 * **pools**: this is a list of IP address pools
 * **prefix**: This is a default prefix for this IPPool
 * **gateway**: This is a default gateway for this IPPool
+* **preAllocations**: This is a default preallocated IP address for this IPPool
 
 The *prefix* and *gateway* can be overridden per pool. The pool definition is
 as follows :


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates api.md with missing spec field and it's definition. 
