### PR TITLE
🏃Rename shortNames with prefix 'm3' or 'metal3'

### DIFF
--- a/api/v1alpha1/ipaddress_types.go
+++ b/api/v1alpha1/ipaddress_types.go
@@ -51,7 +51,7 @@ type IPAddressSpec struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=ipaddresses,scope=Namespaced,categories=metal3,shortName=ipa;ipaddress;ipaddress
+// +kubebuilder:resource:path=ipaddresses,scope=Namespaced,categories=metal3,shortName=ipa;ipaddress;m3ipa;m3ipaddress;m3ipaddresses;metal3ipa;metal3ipaddress;metal3ipaddresses
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // IPAddress is the Schema for the ipaddresses API

--- a/api/v1alpha1/ipclaim_types.go
+++ b/api/v1alpha1/ipclaim_types.go
@@ -45,7 +45,7 @@ type IPClaimStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=ipclaims,scope=Namespaced,categories=cluster-api,shortName=m3ipc;m3ipclaim;ipclaim
+// +kubebuilder:resource:path=ipclaims,scope=Namespaced,categories=cluster-api,shortName=ipc;ipclaim;m3ipc;m3ipclaim;m3ipclaims;metal3ipc;metal3ipclaim;metal3ipclaims
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/ippool_types.go
+++ b/api/v1alpha1/ippool_types.go
@@ -91,7 +91,7 @@ type IPPoolStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:path=ippools,scope=Namespaced,categories=cluster-api,shortName=m3ipp;m3ippool
+// +kubebuilder:resource:path=ippools,scope=Namespaced,categories=cluster-api,shortName=ipp;ippool;m3ipp;m3ippool;m3ippools;metal3ipp;metal3ippool;metal3ippools
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true

--- a/config/crd/bases/ipam.metal3.io_ipaddresses.yaml
+++ b/config/crd/bases/ipam.metal3.io_ipaddresses.yaml
@@ -18,7 +18,12 @@ spec:
     shortNames:
     - ipa
     - ipaddress
-    - ipaddress
+    - m3ipa
+    - m3ipaddress
+    - m3ipaddresses
+    - metal3ipa
+    - metal3ipaddress
+    - metal3ipaddresses
     singular: ipaddress
   scope: Namespaced
   versions:

--- a/config/crd/bases/ipam.metal3.io_ipclaims.yaml
+++ b/config/crd/bases/ipam.metal3.io_ipclaims.yaml
@@ -16,9 +16,14 @@ spec:
     listKind: IPClaimList
     plural: ipclaims
     shortNames:
+    - ipc
+    - ipclaim
     - m3ipc
     - m3ipclaim
-    - ipclaim
+    - m3ipclaims
+    - metal3ipc
+    - metal3ipclaim
+    - metal3ipclaims
     singular: ipclaim
   scope: Namespaced
   versions:

--- a/config/crd/bases/ipam.metal3.io_ippools.yaml
+++ b/config/crd/bases/ipam.metal3.io_ippools.yaml
@@ -16,8 +16,14 @@ spec:
     listKind: IPPoolList
     plural: ippools
     shortNames:
+    - ipp
+    - ippool
     - m3ipp
     - m3ippool
+    - m3ippools
+    - metal3ipp
+    - metal3ippool
+    - metal3ippools
     singular: ippool
   scope: Namespaced
   versions:


### PR DESCRIPTION
This is used to avoid naming conflicts with k8s resources' names.
