### PR TITLE
🐛 Fix issue with pre-allocated addresses

### DIFF
--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"math/big"
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+// GetIPAddress renders the IP address, taking the index, offset and step into
+// account, it is IP version agnostic
+func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
+
+	if entry.Start == nil && entry.Subnet == nil {
+		return "", errors.New("Either Start or Subnet is required for ipAddress")
+	}
+	var ip net.IP
+	var err error
+	var ipNet *net.IPNet
+	offset := index
+
+	// If start is given, use it to add the offset
+	if entry.Start != nil {
+		var endIP net.IP
+		if entry.End != nil {
+			endIP = net.ParseIP(string(*entry.End))
+		}
+		ip, err = addOffsetToIP(net.ParseIP(string(*entry.Start)), endIP, offset)
+		if err != nil {
+			return "", err
+		}
+
+		// Verify that the IP is in the subnet
+		if entry.Subnet != nil {
+			_, ipNet, err = net.ParseCIDR(string(*entry.Subnet))
+			if err != nil {
+				return "", err
+			}
+			if !ipNet.Contains(ip) {
+				return "", errors.New("IP address out of bonds")
+			}
+		}
+
+		// If it is not given, use the CIDR ip address and increment the offset by 1
+	} else {
+		ip, ipNet, err = net.ParseCIDR(string(*entry.Subnet))
+		if err != nil {
+			return "", err
+		}
+		offset++
+		ip, err = addOffsetToIP(ip, nil, offset)
+		if err != nil {
+			return "", err
+		}
+
+		// Verify that the ip is in the subnet
+		if !ipNet.Contains(ip) {
+			return "", errors.New("IP address out of bonds")
+		}
+	}
+	return IPAddressStr(ip.String()), nil
+}
+
+// addOffsetToIP computes the value of the IP address with the offset. It is
+// IP version agnostic
+// Note that if the resulting IP address is in the format ::ffff:xxxx:xxxx then
+// ip.String will fail to select the correct type of ip
+func addOffsetToIP(ip, endIP net.IP, offset int) (net.IP, error) {
+	ip4 := false
+	//ip := net.ParseIP(ipString)
+	if ip.To4() != nil {
+		ip4 = true
+	}
+
+	// Create big integers
+	IPInt := big.NewInt(0)
+	OffsetInt := big.NewInt(int64(offset))
+
+	// Transform the ip into an int. (big endian function)
+	IPInt = IPInt.SetBytes(ip)
+
+	// add the two integers
+	IPInt = IPInt.Add(IPInt, OffsetInt)
+
+	// return the bytes list
+	IPBytes := IPInt.Bytes()
+
+	IPBytesLen := len(IPBytes)
+
+	// Verify that the IPv4 or IPv6 fulfills theirs constraints
+	if (ip4 && IPBytesLen > 6 && IPBytes[4] != 255 && IPBytes[5] != 255) ||
+		(!ip4 && IPBytesLen > 16) {
+		return nil, errors.New(fmt.Sprintf("IP address overflow for : %s", ip.String()))
+	}
+
+	//transform the end ip into an Int to compare
+	if endIP != nil {
+		endIPInt := big.NewInt(0)
+		endIPInt = endIPInt.SetBytes(endIP)
+		// Computed IP is higher than the end IP
+		if IPInt.Cmp(endIPInt) > 0 {
+			return nil, errors.New(fmt.Sprintf("IP address out of bonds for : %s", ip.String()))
+		}
+	}
+
+	// COpy the output back into an ip
+	copy(ip[16-IPBytesLen:], IPBytes)
+	return ip, nil
+}

--- a/api/v1alpha1/utils_test.go
+++ b/api/v1alpha1/utils_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("IPPool manager", func() {
+	type testCaseGetIPAddress struct {
+		ipAddress   Pool
+		index       int
+		expectError bool
+		expectedIP  IPAddressStr
+	}
+
+	DescribeTable("Test getIPAddress",
+		func(tc testCaseGetIPAddress) {
+			result, err := GetIPAddress(tc.ipAddress, tc.index)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(tc.expectedIP))
+			}
+		},
+		Entry("Empty Start and Subnet", testCaseGetIPAddress{
+			ipAddress:   Pool{},
+			index:       1,
+			expectError: true,
+		}),
+		Entry("Start set, no end or subnet", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start: (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+			},
+			index:      1,
+			expectedIP: IPAddressStr("192.168.0.11"),
+		}),
+		Entry("Start set, end set, subnet unset", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start: (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+				End:   (*IPAddressStr)(pointer.StringPtr("192.168.0.100")),
+			},
+			index:      1,
+			expectedIP: IPAddressStr("192.168.0.11"),
+		}),
+		Entry("Start set, end set, subnet unset, out of bound", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start: (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+				End:   (*IPAddressStr)(pointer.StringPtr("192.168.0.100")),
+			},
+			index:       100,
+			expectError: true,
+		}),
+		Entry("Start set, end unset, subnet set", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start:  (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("192.168.0.0/24")),
+			},
+			index:      1,
+			expectedIP: IPAddressStr("192.168.0.11"),
+		}),
+		Entry("Start set, end unset, subnet set, out of bound", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start:  (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("192.168.0.0/24")),
+			},
+			index:       250,
+			expectError: true,
+		}),
+		Entry("Start set, end unset, subnet empty", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Start:  (*IPAddressStr)(pointer.StringPtr("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("")),
+			},
+			index:       1,
+			expectError: true,
+		}),
+		Entry("subnet empty", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("")),
+			},
+			index:       1,
+			expectError: true,
+		}),
+		Entry("Start unset, end unset, subnet set", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("192.168.0.10/24")),
+			},
+			index:      1,
+			expectedIP: IPAddressStr("192.168.0.12"),
+		}),
+		Entry("Start unset, end unset, subnet set, out of bound", testCaseGetIPAddress{
+			ipAddress: Pool{
+				Subnet: (*IPSubnetStr)(pointer.StringPtr("192.168.0.10/24")),
+			},
+			index:       250,
+			expectError: true,
+		}),
+	)
+
+	type testCaseAddOffsetToIP struct {
+		ip          string
+		endIP       string
+		offset      int
+		expectedIP  string
+		expectError bool
+	}
+
+	DescribeTable("Test AddOffsetToIP",
+		func(tc testCaseAddOffsetToIP) {
+			testIP := net.ParseIP(tc.ip)
+			testEndIP := net.ParseIP(tc.endIP)
+			expectedIP := net.ParseIP(tc.expectedIP)
+
+			result, err := addOffsetToIP(testIP, testEndIP, tc.offset)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(expectedIP))
+			}
+		},
+		Entry("valid IPv4", testCaseAddOffsetToIP{
+			ip:         "192.168.0.10",
+			endIP:      "192.168.0.200",
+			offset:     10,
+			expectedIP: "192.168.0.20",
+		}),
+		Entry("valid IPv4, no end ip", testCaseAddOffsetToIP{
+			ip:         "192.168.0.10",
+			offset:     1000,
+			expectedIP: "192.168.3.242",
+		}),
+		Entry("Over bound ipv4", testCaseAddOffsetToIP{
+			ip:          "192.168.0.10",
+			endIP:       "192.168.0.200",
+			offset:      1000,
+			expectError: true,
+		}),
+		Entry("error ipv4", testCaseAddOffsetToIP{
+			ip:          "255.255.255.250",
+			offset:      10,
+			expectError: true,
+		}),
+		Entry("valid IPv6", testCaseAddOffsetToIP{
+			ip:         "2001::10",
+			endIP:      "2001::fff0",
+			offset:     10,
+			expectedIP: "2001::1A",
+		}),
+		Entry("valid IPv6, no end ip", testCaseAddOffsetToIP{
+			ip:         "2001::10",
+			offset:     10000,
+			expectedIP: "2001::2720",
+		}),
+		Entry("Over bound ipv6", testCaseAddOffsetToIP{
+			ip:          "2001::10",
+			endIP:       "2001::00f0",
+			offset:      10000,
+			expectError: true,
+		}),
+		Entry("error ipv6", testCaseAddOffsetToIP{
+			ip:          "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFF0",
+			offset:      100,
+			expectError: true,
+		}),
+	)
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
In case of pre-allocated addresses, the claims were not given the
proper prefix, gateway and dns server overrides. In addition to
fixing this, some validations on the pool updates are added to
verify that no addresses would be out of bonds.