### PR TITLE
🐛 Fix examples generation

### DIFF
--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -78,14 +78,15 @@ kustomize build "${SOURCE_DIR}/ippool" | envsubst > "${IPPOOL_GENERATED_FILE}"
 echo "Generated ${IPPOOL_GENERATED_FILE}"
 
 # Get Cert-manager provider components file
-curl -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/jetstack/cert-manager/releases/download/v0.13.0/cert-manager.yaml
+curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
+echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.
-kustomize build "github.com/kubernetes-sigs/cluster-api/config/?ref=master" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
+kustomize build "github.com/kubernetes-sigs/cluster-api/config/default/?ref=master" > "${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_CLUSTER_API_GENERATED_FILE}"
 
 # Generate METAL3 Infrastructure Provider components file.
-kustomize build "${SOURCE_DIR}/../config" | envsubst > "${COMPONENTS_METAL3_GENERATED_FILE}"
+kustomize build "${SOURCE_DIR}/../config/default" | envsubst > "${COMPONENTS_METAL3_GENERATED_FILE}"
 echo "Generated ${COMPONENTS_METAL3_GENERATED_FILE}"
 
 # Generate a single provider components file.

--- a/examples/ippool/ippool.yaml
+++ b/examples/ippool/ippool.yaml
@@ -1,35 +1,41 @@
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     services:
       cidrBlocks: ["10.96.0.0/12"]
     pods:
-      cidrBlocks: ["192.168.0.0/16"]
+      cidrBlocks: ["192.168.0.0/18"]
     serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha5
     kind: Metal3Cluster
     name: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
     name: ${CLUSTER_NAME}-controlplane
+    namespace: ${NAMESPACE}
 ---
 apiVersion: ipam.metal3.io/v1alpha1
 kind: IPPool
 metadata:
   name: pool1
+  namespace: ${NAMESPACE}
 spec:
   clusterName: ${CLUSTER_NAME}
+  namePrefix: ${CLUSTER_NAME}-prov
 ---
 apiVersion: ipam.metal3.io/v1alpha1
 kind: IPClaim
 metadata:
-  name: Claim1
+  name: ${CLUSTER_NAME}-controlplane-template-0-provisioning-pool
 spec:
-  Pool:
-    Name: pool1
+  pool:
+    name: pool1
+    namespace: ${NAMESPACE}


### PR DESCRIPTION
Fixes examples generation after CAPI uplift to v1a4.
Makes sure to run:

**- make deploy**
**- make deploy-examples**
**- make delete-examples**

Makefile targets successfully. 