### PR TITLE
✨ Add AGE column to IPAM CRDs

### DIFF
--- a/api/v1alpha1/ipaddress_types.go
+++ b/api/v1alpha1/ipaddress_types.go
@@ -52,6 +52,7 @@ type IPAddressSpec struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:path=ipaddresses,scope=Namespaced,categories=metal3,shortName=ipa;ipaddress;m3ipa;m3ipaddress;m3ipaddresses;metal3ipa;metal3ipaddress;metal3ipaddresses
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3IPAddress"
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // IPAddress is the Schema for the ipaddresses API

--- a/api/v1alpha1/ipclaim_types.go
+++ b/api/v1alpha1/ipclaim_types.go
@@ -49,6 +49,7 @@ type IPClaimStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3IPClaim"
 // IPClaim is the Schema for the ipclaims API
 type IPClaim struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/ippool_types.go
+++ b/api/v1alpha1/ippool_types.go
@@ -96,7 +96,7 @@ type IPPoolStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this template belongs"
-
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Metal3IPPool"
 // IPPool is the Schema for the ippools API
 type IPPool struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/ipam.metal3.io_ipaddresses.yaml
+++ b/config/crd/bases/ipam.metal3.io_ipaddresses.yaml
@@ -27,7 +27,12 @@ spec:
     singular: ipaddress
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3IPAddress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IPAddress is the Schema for the ipaddresses API
@@ -146,6 +151,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/ipam.metal3.io_ipclaims.yaml
+++ b/config/crd/bases/ipam.metal3.io_ipclaims.yaml
@@ -27,7 +27,12 @@ spec:
     singular: ipclaim
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Metal3IPClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: IPClaim is the Schema for the ipclaims API

--- a/config/crd/bases/ipam.metal3.io_ippools.yaml
+++ b/config/crd/bases/ipam.metal3.io_ippools.yaml
@@ -32,6 +32,10 @@ spec:
       jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
       name: Cluster
       type: string
+    - description: Time duration since creation of Metal3IPPool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
This adds the AGE column to all our CRDs to make the printed output consistent with the built in K8s resources.

Keeping things consistent with CAPI# https://github.com/kubernetes-sigs/cluster-api/pull/5180