### PR TITLE
🐛 Fix kustomization in release-0.0 branch

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -21,4 +21,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: ipam-serving-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -23,4 +23,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: $(SERVICE_NAME)-cert
+          secretName: ipam-serving-cert


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in kustomization where cert-manager ca inject annotation for ipam-serving-cert does not contain capm3 namePrefix but the name of the certificate does for release-0.0 branch of IPAM.


