### PR TITLE
🐛 Use non root user with id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     -o manager .
 
 # Copy the controller-manager into a thin image
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nobody
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
+USER 65532
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
 Uses nonroot user for IPAM. This is porting a similar PR from [CAPI](https://github.com/kubernetes-sigs/cluster-api/pull/4064)

