### PR TITLE
:sparkles: Update the contract labels for IPAM CRDS

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,6 +7,8 @@ kind: Kustomization
 commonLabels:
   cluster.x-k8s.io/v1alpha2: v1alpha2
   cluster.x-k8s.io/v1alpha3: v1alpha3_v1alpha4
+  cluster.x-k8s.io/v1alpha4: v1alpha5
+  cluster.x-k8s.io/v1beta1: v1beta1
 
 resources:
 - bases/ipam.metal3.io_ippools.yaml


### PR DESCRIPTION
It is needed to conform with the CAPI CRD labeling

Related documentation can be found here:
https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#apply-the-contract-version-label-clusterx-k8sioversion-version1_version2_version3-to-your-crds

This update was also done to CAPM3, the current CAPM3 CRD labeling configuration can be found here:
https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/config/crd/kustomization.yaml