### PR TITLE
🌱 Use golang image as base for unit test containers

### DIFF
--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -9,7 +9,6 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   export XDG_CACHE_HOME=/tmp/.cache
   mkdir /tmp/unit
   cp -r ./* /tmp/unit
-  cp -r /usr/local/kubebuilder/bin /tmp/unit/hack/tools
   cd /tmp/unit
   make test
 else
@@ -18,6 +17,6 @@ else
     --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
     --entrypoint sh \
     --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    quay.io/metal3-io/capm3-unit:master \
+    docker.io/golang:1.17 \
     /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/unit.sh "${@}"
 fi;


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `docker.io/golang:1.17`  container image for unit.sh script.
We don't necessarily need to create & use `quay.io/metal3-io/capm3-unit`
image, because the only thing this image has is kustomize and
kubebuilder installed via below RUN, which is redundant as those
binaries will be installed during `unit` Makefile target ( as part of
`setup_envs`). At the end, we currently install kubebuilder and
kustomize twice. 
```
 RUN ./install_kustomize.sh && \
    ./install_kubebuilder.sh

```
There will be a follow PR to this, which will remove the
Dockerfile, and update the project-infra respectively to migrate
fully to golang images.