### PR TITLE
🌱Use golang as base image and fix capm3 mentions

### DIFF
--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -14,9 +14,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/metal3-ipam:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /metal3-ipam \
     registry.hub.docker.com/library/golang:1.16 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/gofmt.sh
+    /metal3-ipam/hack/gofmt.sh
 fi;

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -14,9 +14,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/metal3-ipam:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
+    --workdir /metal3-ipam \
     registry.hub.docker.com/library/golang:1.16 \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/govet.sh
+    /metal3-ipam/hack/govet.sh
 fi;

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -9,15 +9,15 @@ if [ "${IS_CONTAINER}" != "false" ]; then
   export XDG_CACHE_HOME=/tmp/.cache
   mkdir /tmp/unit
   cp -r ./* /tmp/unit
-  cp -r /usr/local/kubebuilder/bin /tmp/unit/hack/tools
   cd /tmp/unit
   make test
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/metal3-io/cluster-api-provider-metal3:ro,z" \
+    --volume "${PWD}:/metal3-ipam:ro,z" \
     --entrypoint sh \
-    --workdir /go/src/github.com/metal3-io/cluster-api-provider-metal3 \
-    quay.io/metal3-io/capbm-unit:master \
-    /go/src/github.com/metal3-io/cluster-api-provider-metal3/hack/unit.sh "${@}"
+    --workdir /metal3-ipam \
+     docker.io/golang:1.16 \
+    /metal3-ipam/hack/unit.sh "${@}"
+    
 fi;


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of https://github.com/metal3-io/ip-address-manager/pull/77 into release-0.0 branch with slight more changes that removes unrelated capm3 mentions in hack/*.sh files 
