### PR TITLE
✨Use grouping feature of Tilt to add IPAM label

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -4,7 +4,15 @@
         "kustomize_config": false,
         "image": "quay.io/metal3-io/ip-address-manager",
         "live_reload_deps": [
-            "api", "ipam", "config", "controllers", "go.mod", "go.sum", "main.go"
-        ]
+            "api",
+            "ipam",
+            "config",
+            "controllers",
+            "go.mod",
+            "go.sum",
+            "main.go"
+        ],
+        "label": "IPAM",
+        "manager_name": "ipam-controller-manager"
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update tilt-provider.json to add IPAM label in Tilt UX. This [grouping feature](https://blog.tilt.dev/2021/08/09/resource-grouping.html) is supported in tilt version >= v0.22.2.
This patch provides two different grouping strategies:

- by controllers
- and local binaries

Also, the corresponding controller and binary will be grouped under 'IPAM' group label as shown in the local Tilt setup using BMO,CAPM3&IPAM controllers.

![ipam](https://user-images.githubusercontent.com/40443040/147974824-8741172e-a67b-446d-b4ae-cea28c8a924a.png)

Related patches in: [CAPM3](https://github.com/metal3-io/cluster-api-provider-metal3/pull/385)&[BMO](https://github.com/metal3-io/baremetal-operator/pull/1061).
