### PR TITLE
📖 Add Michael Captain as a reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,4 @@ approvers:
  - furkatgofurov7
 
 reviewers:
-- jan-est
+- macaptain


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Jan left the project, currently we have no one on the reviewers' list in the repository. For that reason, this PR removes Jan (@jan-est) from the reviewers' list and proposes to add Michael (@macaptain) to the list as agreed offline.

