### PR TITLE
🌱 Move maelk to emeritus_approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,12 @@
 
 approvers:
  - russellb
- - maelk
  - kashifest
  - fmuyassarov
  - furkatgofurov7
 
 reviewers:
-- macaptain
+ - macaptain
+
+emeritus_approvers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.
