### PR TITLE
🌱 Uplift CAPI module to v0.4.8 in release-0.1 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/client-go v0.21.4
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/utils v0.0.0-20210802155522-efc7438f0176
-	sigs.k8s.io/cluster-api v0.4.7
+	sigs.k8s.io/cluster-api v0.4.8
 	sigs.k8s.io/controller-runtime v0.9.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1044,8 +1044,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/cluster-api v0.4.7 h1:XzIn48gZAEDyxP/fMcGqOfrgMSLwbcUMgyPRqMeZTjs=
-sigs.k8s.io/cluster-api v0.4.7/go.mod h1:KKycu4yJEm1sxKG5UaHX9ZnYxRiBzJsFjJVmvMQUP2k=
+sigs.k8s.io/cluster-api v0.4.8 h1:CnkkFSeMHrranzfjqXuMwJmlq0wkoaJetbV/Njb7RBc=
+sigs.k8s.io/cluster-api v0.4.8/go.mod h1:KKycu4yJEm1sxKG5UaHX9ZnYxRiBzJsFjJVmvMQUP2k=
 sigs.k8s.io/controller-runtime v0.9.7 h1:DlHMlAyLpgEITVvNsuZqMbf8/sJl9HirmCZIeR5H9mQ=
 sigs.k8s.io/controller-runtime v0.9.7/go.mod h1:nExcHcQ2zvLMeoO9K7rOesGCmgu32srN5SENvpAEbGA=
 sigs.k8s.io/kustomize/api v0.8.8/go.mod h1:He1zoK0nk43Pc6NlV085xDXDXTNprtcyKZVm3swsdNY=


### PR DESCRIPTION
**What this PR does / why we need it**:
Uplift release-0.1 branch to use latest CAPI release https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.4.8 in v1a4 release series 

