### PR TITLE
 🐛 Don't consider IPAddresses in use when IPPool is being deleted

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -112,8 +112,14 @@ func (m *IPPoolManager) getIndexes(ctx context.Context) (map[ipamv1.IPAddressStr
 
 	addresses := make(map[ipamv1.IPAddressStr]string)
 
-	for _, address := range m.IPPool.Spec.PreAllocations {
-		addresses[address] = ""
+	// After addresses map is populated, we consider that there are still addresses in use.
+	// However, when IPPool.Spec.PreAllocations is given, it can still hold addresses even
+	// though they are already deleted. This consideration should be valid only when
+	// IPPool does not have DeletionTimestamp set.
+	if m.IPPool.DeletionTimestamp.IsZero() {
+		for _, address := range m.IPPool.Spec.PreAllocations {
+			addresses[address] = ""
+		}
 	}
 
 	// get list of IPAddress objects

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -265,6 +265,41 @@ var _ = Describe("IPPool manager", func() {
 				"abc": ipamv1.IPAddressStr("abcd1"),
 			},
 		}),
+		Entry("IPPool with deletion timestamp", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &timeNow,
+				},
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"bcd": ipamv1.IPAddressStr("bcde"),
+					},
+				},
+			},
+			addresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-11",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "inUseClaim",
+							Namespace: "myns",
+						},
+						Address: ipamv1.IPAddressStr("192.168.1.11"),
+						Gateway: (*ipamv1.IPAddressStr)(pointer.StringPtr("192.168.0.1")),
+						Prefix:  24,
+					},
+				},
+			},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+		}),
 	)
 
 	var ipPoolMeta = metav1.ObjectMeta{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Related to: https://github.com/metal3-io/cluster-api-provider-metal3/pull/656
