### PR TITLE
🌱 Protect IPAddresses and IPClaims from accidental deletion

### DIFF
--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -60,7 +60,7 @@ type IPPoolReconciler struct {
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile handles Metal3Machine events.
+// Reconcile handles IPPool events.
 func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	ctx = context.Background()
 	metadataLog := r.Log.WithName(ipPoolControllerName).WithValues("metal3-ippool", req.NamespacedName)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds a finalizer to all IPAddresses to prevent accidental deletion of them
- Adds a check before deleting IPClaims (and the associated IPAddresses) to see if it is still in use. If the IPClaim has an owner reference to a Metal3Data, it is considered still in use.
- Some confusing comments and log messages edited.


This PR depends on https://github.com/metal3-io/cluster-api-provider-metal3/pull/685 since CAPM3 does not remove the owner refs otherwise, so we get stuck while deleting IPClaims (waiting on the owner ref to go away.

I'm a bit unsure if this should be considered a "feature" or something else. Put 🌱 "other" for now.