### PR TITLE
🐛 Always patch IPClaim

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -212,17 +212,17 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 	if err != nil {
 		return addresses, errors.Wrap(err, "failed to init patch helper")
 	}
+	// Always patch addressClaim exiting this function so we can persist any changes.
+	defer func() {
+		err := helper.Patch(ctx, addressClaim)
+		if err != nil {
+			m.Log.Error(err, "failed to Patch IPClaim")
+		}
+	}()
 
 	addressClaim.Status.ErrorMessage = nil
 
 	if addressClaim.DeletionTimestamp.IsZero() {
-		// Always patch addressClaim exiting this function so we can persist any changes.
-		defer func() {
-			err := helper.Patch(ctx, addressClaim)
-			if err != nil {
-				m.Log.Error(err, "failed to Patch IPClaim")
-			}
-		}()
 		addresses, err = m.createAddress(ctx, addressClaim, addresses)
 		if err != nil {
 			return addresses, err


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/metal3-io/ip-address-manager/pull/126 I wrongly moved the defer, so that we only patch when the IPClaim has no deletion timestamp. This was wrong, because we need to patch the deleting IPClaims in order to remove the finalizer!

The reason I moved it before, was that the logs were full of attempts to patch IPClaims that were already deleted, so I thought it was unnecessary to patch them.
