### PR TITLE
🌱 Use finalizers instead of ownerRefs to check if IPClaim is in use

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -224,11 +224,12 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 			return addresses, err
 		}
 	} else {
-		// Check if this claim is in use. Does it have any owners?
+		// Check if this claim is in use. Does it have any other finalizers than our own?
 		// If it is no longer in use, proceed to delete the associated IPAddress
-		if len(addressClaim.OwnerReferences) > 0 {
-			m.Log.Info("IPClaim is still in use (has owners). Cannot delete IPAddress.",
-				"IPClaim", addressClaim.Name, "Owners", addressClaim.OwnerReferences)
+		if len(addressClaim.Finalizers) > 1 ||
+			(len(addressClaim.Finalizers) == 1 && !Contains(addressClaim.Finalizers, ipamv1.IPClaimFinalizer)) {
+			m.Log.Info("IPClaim is still in use (has other finalizers). Cannot delete IPAddress.",
+				"IPClaim", addressClaim.Name, "Finalizers", addressClaim.Finalizers)
 			return addresses, nil
 		}
 

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -470,7 +470,7 @@ var _ = Describe("IPPool manager", func() {
 			},
 			expectedNbAllocations: 2,
 		}),
-		Entry("IPClaim with deletion timestamp without owner", testCaseUpdateAddresses{
+		Entry("IPClaim with deletion timestamp without finalizers", testCaseUpdateAddresses{
 			ipPool: &ipamv1.IPPool{
 				ObjectMeta: ipPoolMeta,
 				Spec: ipamv1.IPPoolSpec{
@@ -517,7 +517,7 @@ var _ = Describe("IPPool manager", func() {
 			expectedAllocations:   map[string]ipamv1.IPAddressStr{},
 			expectedNbAllocations: 0,
 		}),
-		Entry("IPClaim with deletion timestamp and owner", testCaseUpdateAddresses{
+		Entry("IPClaim with deletion timestamp and finalizers", testCaseUpdateAddresses{
 			ipPool: &ipamv1.IPPool{
 				ObjectMeta: ipPoolMeta,
 				Spec: ipamv1.IPPoolSpec{
@@ -531,12 +531,9 @@ var _ = Describe("IPPool manager", func() {
 						Name:              "inUseClaim",
 						Namespace:         "myns",
 						DeletionTimestamp: &timeNow,
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Kind:       "Metal3Data",
-								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-								Name:       "owner",
-							},
+						Finalizers: []string{
+							ipamv1.IPClaimFinalizer,
+							"metal3data.infrastructure.cluster.x-k8s.io",
 						},
 					},
 					Spec: ipamv1.IPClaimSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous implementation was API breaking, since it required the
user/controller owning the IPClaim to remove the ownerRef before the
IPAddress would be deleted. This commit changes it so that we check for
finalizers instead. More specifically, if there are any other finalizers
than the IPAM one, we consider the IPClaim to be still in use. In this
way we "revert" the API breaking change but still get the same
functionality.
