### PR TITLE
Add deletion validation for IPPool webhook

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -141,6 +141,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - ippools
   sideEffects: None


### PR DESCRIPTION
The webhook should reject IPPool deletion if any IP has been allocated

Fixes https://github.com/metal3-io/ip-address-manager/issues/135
