### PR TITLE
📖 Update IPAM compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ For more information about this controller and related repositories, see
 
 | IPAM version      | CAPM3 version     | Cluster API version | IPAM Release |
 |-------------------|-------------------|---------------------|--------------|
-| v1alpha1 (v0.0.X) | v1alpha4 (v0.4.X) | v1alpha3 (v0.3.X)   | v0.0.X       |
 | v1alpha1 (v0.1.X) | v1alpha5 (v0.5.X) | v1alpha4 (v0.4.X)   | v0.1.X       |
 | v1alpha1 (v1.1.X) | v1beta1 (v1.1.X)  | v1beta1 (v1.1.X)    | v1.1.X       |
+| v1alpha1 (v1.2.X) | v1beta1 (v1.2.X)  | v1beta1 (v1.2.X)    | v1.2.X       |
 
 ## Development Environment
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/metal3-io/ip-address-manager/releases/tag/v1.2.0 is out and we are using the latest versions of CAPI/CAPM3 (v1.2.x) so updates compatibility table accordingly