### PR TITLE
🌱Add CAPI metadata.yaml and add namespace resource in release manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,8 @@ $(RELEASE_NOTES_DIR):
 .PHONY: release-manifests
 release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publish with a release
 	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/ipam-components.yaml
+	# Add metadata to the release artifacts
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -10,6 +10,9 @@ namePrefix: ipam-
 commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-metal3"
 
+resources:
+- namespace.yaml
+
 bases:
 - ../rbac
 - ../manager

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,20 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 4
+    contract: v1alpha1
+  - major: 1
+    minor: 3
+    contract: v1alpha1
+  - major: 1
+    minor: 2
+    contract: v1alpha1
+  - major: 1
+    minor: 1
+    contract: v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CAPI metadata.yaml and add namespace resource in release manifests
- metadata.yaml is needed by CAPI clusterctl.
- namespace capm3-system is needed for deploying ip-address-manager.

Refer to CAPI files:
- https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.2
- https://github.com/kubernetes-sigs/cluster-api/blob/v1.2.2/Makefile#L748
- https://github.com/kubernetes-sigs/cluster-api/blob/v1.2.2/config/default/kustomization.yaml#L8

