### PR TITLE
🌱 Remove unit test container image building Dockerfile

### DIFF
--- a/hack/Dockerfile.unit
+++ b/hack/Dockerfile.unit
@@ -1,6 +1,0 @@
-FROM registry.hub.docker.com/library/golang:1.18
-
-WORKDIR /usr/local/kubebuilder
-COPY /hack/tools /usr/local/kubebuilder/
-RUN ./install_kustomize.sh && \
-    ./install_kubebuilder.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead use prow tests and get rid of building extra container image just for unit tests


