### PR TITLE
🌱 Uplift CAPI to v1.3.2 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/component-base v0.25.0
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	sigs.k8s.io/cluster-api v1.3.1
+	sigs.k8s.io/cluster-api v1.3.2
 	sigs.k8s.io/controller-runtime v0.13.1
 
 )

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,8 @@ k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.3.1 h1:sFd/ayOhQxd4YZX1qw8HC2xO7eKRBNRL+mlCKwdVhvY=
-sigs.k8s.io/cluster-api v1.3.1/go.mod h1:ef5vvtp2PyhEHTYCw8niaVPlOX5Ntvrh+8oBZt0PJ08=
+sigs.k8s.io/cluster-api v1.3.2 h1:DkkaVASrxgOP4hT24ndGwfge8+YjHKuAyZBSGJwAlq4=
+sigs.k8s.io/cluster-api v1.3.2/go.mod h1:nnXmR51rHshpMEXmB4LZIwdiXWKXV6yaooB1KzrL0Qs=
 sigs.k8s.io/controller-runtime v0.13.1 h1:tUsRCSJVM1QQOOeViGeX3GMT3dQF1eePPw6sEE3xSlg=
 sigs.k8s.io/controller-runtime v0.13.1/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.3.2
