### PR TITLE
✨ add explicit securitycontexts to controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,35 +18,47 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /manager
-        args:
-          - "--webhook-port=9443"
-        image: controller:latest
-        imagePullPolicy: IfNotPresent
-        name: manager
-        env:
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        ports:
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
+        - command:
+            - /manager
+          args:
+            - "--webhook-port=9443"
+          image: controller:latest
+          imagePullPolicy: IfNotPresent
+          name: manager
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsUser: 65532
+            runAsGroup: 65532
       terminationGracePeriodSeconds: 10
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: manager
       tolerations:
-      # TODO (fmuyassarov): remove node-role.kubernetes.io/master
-      # taint before moving to k8s v1.24
+        # TODO (fmuyassarov): remove node-role.kubernetes.io/master
+        # taint before moving to k8s v1.24
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
         - effect: NoSchedule


### PR DESCRIPTION
It is always good to not rely on the defaults, but be explicit. Set explicit, secure securityContext for the IPAM controller manager deployment and containers.

CAPI has the same starting from upcoming v1.4.0 and cert-manager etc has them already.

Also, reindent manifest properly.