### PR TITLE
hack: gomod needs to verify all go.mod files

### DIFF
--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -5,44 +5,40 @@
 #
 # NOTE: This won't work unless the build environment has internet access
 
-set -ux
+set -eux
 
 IS_CONTAINER=${IS_CONTAINER:-false}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-  export XDG_CACHE_HOME="/tmp/.cache"
+    export XDG_CACHE_HOME=/tmp/.cache
 
-  STATUS=$(git status --porcelain)
-  if [ -n "$STATUS" ]; then
-      echo "Dirty tree: refusing to continue out of caution"
-      exit 1
-  fi
+    mkdir /tmp/gomod
+    cp -r . /tmp/gomod
+    cd /tmp/gomod
 
-  go mod tidy
-  rc=$?
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "Dirty tree: refusing to continue out of caution"
+        exit 1
+    fi
 
-  if [ $rc -ne 0 ]; then
-      echo "'go mod tidy' failed"
-      exit 1;
-  fi
+    make modules
 
-  STATUS=$(git status --porcelain go.mod go.sum)
-  if [ -n "$STATUS" ]; then
-      echo "go.mod and go.sum changed"
-      echo "Please run 'go mod tidy' and commit the changes to go.mod & go.sum."
-      echo "Abort"
-      exit 1
-  fi
-
-  exit 0;
+    STATUS="$(git status --porcelain)"
+    if [ -n "${STATUS}" ]; then
+        echo "one of the go.mod and/or go.sum files changed"
+        echo "${STATUS}"
+        echo "Please run 'go mod tidy' and commit the changes"
+        exit 1
+    fi
 
 else
-  "${CONTAINER_RUNTIME}" run --rm \
-    --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/metal3-ipam:ro,z"  \
-    --entrypoint sh \
-    --workdir /metal3-ipam \
-    registry.hub.docker.com/library/golang:1.17 \
-    /metal3-ipam/hack/gomod.sh "${@}"
-fi;
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/golang:1.18 \
+        /workdir/hack/gomod.sh "$@"
+fi


### PR DESCRIPTION
gomod.sh has only checked top-level go.mod/go.sum so far, which means api/ and hack/tools go.mods have not been verified.

The script also did not work locally at all, since /workdir was mounted read-only and "go mod tidy" writes to the directory.

Utilize existing "make modules" target.

Uplift Go from insecure 1.17 to 1.18.

Manual backport of #199 