### PR TITLE
🌱 Disable scheduled workflows from running in forks

### DIFF
--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   setup:
+    # This workflow is only of value to the metal3-io/ip-address-manager repository and
+    # would always fail in forks
+    if: github.repository == 'metal3-io/ip-address-manager'
     runs-on: ubuntu-20.04
     permissions:
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ jobs:
   build:
     permissions:
       contents: write
+    # This workflow is only of value to the metal3-io/ip-address-manager repository and
+    # would always fail in forks
+    if: github.repository == 'metal3-io/ip-address-manager'
     runs-on: ubuntu-latest
     steps:
       - name: Export RELEASE_TAG var


### PR DESCRIPTION
Workflows use resources that are only available when run in the [metal3-io/ip-address-manager](https://github.com/metal3-io/ip-address-manager) repository, so workflow run would always fail when they run in a forked repository. They are of no value to fork repositories. They are triggered by the schedule event, so they cause regular annoying and confusing workflow failure notifications for every fork owner. Rather checking these workflows only in upstream repo is enough.