### PR TITLE
📖 fix broken links in markdown files

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,7 +1,7 @@
 # Versioning
 
 Those guidelines are coming from
-[Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/main/VERSIONING.md)
+[Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md)
 as we try to follow closely the release process
 
 <!-- markdownlint-disable -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,4 @@ The *spec* field contains the following :
 ## Metal3 dev env examples
 
 You can find CR examples in the
-[Metal3-io dev env project](https://github.com/metal3-io/metal3-dev-env),
-in the [template
-folder](https://github.com/metal3-io/metal3-dev-env/tree/master/vm-setup/roles/v1aX_integration_test/templates).
+[Metal3-io dev env project](https://github.com/metal3-io/metal3-dev-env)


### PR DESCRIPTION
We have two broken links in IPAM:
- CAPI VERSIONING.md is now part of CONTRIBUTING.md
- metal-dev-env integration tests are not doubling as templates anymore

Broken link checker action is added in https://github.com/metal3-io/ip-address-manager/pull/228