### PR TITLE
✨ Add flags for configuring rate limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ tilt.d/*
 
 out
 releasenotes
+
+# Development containers (https://containers.dev/)
+.devcontainer


### PR DESCRIPTION
**What this PR does / why we need it**:

Matching https://github.com/kubernetes-sigs/cluster-api/pull/8579

There is a built-in rate limit for the controller when talking to the Kubernetes API. So far it has not been possible to configure this limit. This commit adds flags for setting both the QPS and the burst for the rate limit. The default remains the same as before (20 QPS, 30 burst).

New flags:

--kube-api-qps
--kube-api-burst

Also adds .devcontainer to .gitignore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
