### PR TITLE
🌱 remove mdlrc and fix the one error it ignored

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,2 +1,0 @@
-#Disable line-length for some code examples in getting-started
-rules "~MD013", "~MD005"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Deploys IPAM CRDs and deploys IPAM controllers
 Runs IPAM controller locally
 
 ```sh
-    kubectl scale -n capm3-system deployment.v1.apps/metal3-ipam-controller-manager \
-      --replicas 0
+    kubectl scale -n capm3-system \
+      deployment.v1.apps/metal3-ipam-controller-manager --replicas 0
     make run
 ```
 


### PR DESCRIPTION
Remove obsolete `.mdlrc` that ignored couple rules, which hide only a single issue.