### PR TITLE
🐛 Add missing github-actions to  dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
@@ -11,7 +11,7 @@ updates:
       prefix: ":seedling:"
     labels:
       - "ok-to-test"
-  # Go
+    # Go
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
github-actions was missing from package-ecosystem in dependabot configuration