### PR TITLE
🌱 Include all gomods in different directories for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,30 @@ updates:
       # Ignore k8s and its transitives modules as they are upgraded manually
       # together with controller-runtime.
       - dependency-name: "k8s.io/*"
-      - dependency-name: "go.etcd.io/*"
-      - dependency-name: "google.golang.org/grpc"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+      # Ignore k8s and its transitives modules as they are upgraded manually
+      # together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+  - package-ecosystem: "gomod"
+    directory: "/hack/tools"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "sigs.k8s.io/controller-tools"
     commit-message:
       prefix: ":seedling:"
     labels:


### PR DESCRIPTION
Dependabot is currently not updating gomodules in api/ and hack/tools dir. This PR updates it.
