### PR TITLE
Add support for mac (kustomize)

### DIFF
--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -3,12 +3,13 @@
 [[ -f bin/kustomize ]] && exit 0
 
 version=4.4.1
-arch=amd64
+arch=$(go env GOARCH)
+os=$(go env GOOS)
 
 mkdir -p ./bin
-curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_linux_${arch}.tar.gz"
+curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_${os}_${arch}.tar.gz"
 
-tar -xzvf "kustomize_v${version}_linux_${arch}.tar.gz"
+tar -xzvf "kustomize_v${version}_${os}_${arch}.tar.gz"
 mv kustomize ./bin
 
-rm "kustomize_v${version}_linux_${arch}.tar.gz"
+rm "kustomize_v${version}_${os}_${arch}.tar.gz"


### PR DESCRIPTION
Fixes:

when `make release-manifests` is executed on anything else than amd64 @ Linux
it is failing on:

```
bash: line 1: hack/tools/bin/kustomize: cannot execute binary file: Exec format error
```
This PR downloads the correct binary of kustomize for user's platform.