### PR TITLE
🌱 bump gosec to 2.17.0, and fix gosec for submodules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,8 +48,13 @@ linters-settings:
     go: "1.20"
     severity: medium
     confidence: medium
-    excludes:
-      - G107
+    concurrency: 8
+    config:
+      # Globals are applicable to all rules.
+      global:
+        # If true, ignore #nosec in comments
+        # Default: false
+        nosec: true
   importas:
       no-unaliased: true
       alias:

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -4,16 +4,21 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+GO_CONCURRENCY="${GO_CONCURRENCY:-8}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME="/tmp/.cache"
-    gosec -exclude=G107 -severity medium -confidence medium -quiet -concurrency 16 ./...
+    # It seems like gosec does not handle submodules well. Therefore we skip them and run separately.
+    gosec -severity medium -confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" -exclude-dir=api ./...
+    (cd api && gosec -severity medium -confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" ./...)
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213 \
+        docker.io/securego/gosec:2.17.0@sha256:4ea9b6053eac43abda841af5885bbd31ee1bf7289675545b8858bcedb40b4fa8 \
         /workdir/hack/gosec.sh
 fi


### PR DESCRIPTION
Gosec does not handle submodules well. Ignore them and run them separately so they run against correct dependencies.

Bump gosec to 2.17.0 and remove any excludes.

NOTE: In CI, the gosec image is coming via project-infra, this change is only affecting local runs until another PR changes the gosec image there.
