### PR TITLE
🌱 don't ignore #nosec in golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,12 +49,6 @@ linters-settings:
     severity: medium
     confidence: medium
     concurrency: 8
-    config:
-      # Globals are applicable to all rules.
-      global:
-        # If true, ignore #nosec in comments
-        # Default: false
-        nosec: true
   importas:
       no-unaliased: true
       alias:


### PR DESCRIPTION
I understood this config wrong way around. With the additional config it ignored the #nosec lines, which means it failed linting where they were ignored. Default is working well for us.
