### PR TITLE
🌱 bump gosec and fix errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
           - ""
           - api
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Calculate go version
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,8 +48,7 @@ linters-settings:
     go: "1.20"
     severity: medium
     confidence: medium
-    excludes:
-      - G107
+    concurrency: 8
   importas:
       no-unaliased: true
       alias:

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -38,7 +38,7 @@ wget_and_verify()
 
     checksum="$(sha256sum "${target}" | awk '{print $1;}')"
     if [[ "${checksum}" != "${sha256}" ]]; then
-        if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION}" == "true" ]]; then
+        if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION:-}" == "true" ]]; then
             echo >&2 "warning: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
         else
             echo >&2 "fatal: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
@@ -61,11 +61,11 @@ download_and_install_golangci_lint()
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
     GOLANGCI_VERSION="1.54.2"
-    case "${KERNEL_OS}" in
-        darwin) GOLANGCI_SHA256="7b33fb1be2f26b7e3d1f3c10ce9b2b5ce6d13bb1d8468a4b2ba794f05b4445e1" ;;
-        linux) GOLANGCI_SHA256="a9f14b33473c65fcfbf411ec054b53a87dbb849f4e09ee438f1ee76dbf3f3d4e" ;;
-      *) 
-        echo >&2 "error:${KERNEL_OS} not supported. Please obtain the binary and calculate sha256 manually."
+    case "${KERNEL_OS}-${ARCH}" in
+        darwin-arm64) GOLANGCI_SHA256="7b33fb1be2f26b7e3d1f3c10ce9b2b5ce6d13bb1d8468a4b2ba794f05b4445e1" ;;
+        linux-amd64) GOLANGCI_SHA256="17c9ca05253efe833d47f38caf670aad2202b5e6515879a99873fabd4c7452b3" ;;
+      *)
+        echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1
         ;;
     esac

--- a/hack/gosec.sh
+++ b/hack/gosec.sh
@@ -4,16 +4,21 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+GO_CONCURRENCY="${GO_CONCURRENCY:-8}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME="/tmp/.cache"
-    gosec -exclude=G107 -severity medium -confidence medium -quiet -concurrency 16 ./...
+    # It seems like gosec does not handle submodules well. Therefore we skip them and run separately.
+    gosec -severity medium -confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" -exclude-dir=api ./...
+    (cd api && gosec -severity medium -confidence medium -quiet \
+        -concurrency "${GO_CONCURRENCY}" ./...)
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/securego/gosec:2.14.0@sha256:73858f8b1b9b7372917677151ec6deeceeaa40c5b02753080bd647dede14e213 \
+        docker.io/securego/gosec:2.17.0@sha256:4ea9b6053eac43abda841af5885bbd31ee1bf7289675545b8858bcedb40b4fa8 \
         /workdir/hack/gosec.sh
 fi


### PR DESCRIPTION
Gosec does not handle submodules well. Ignore them and run them separately so they run against correct dependencies.

Bump gosec to 2.17.0, and fix new errors it has discovered.

Manual cherry pick of #323, #324, #325 and #317 that bump golangci-lint workflow dependencies.

After this has been merged, PR in project-infra is needed to deactivate gosec in release-1.5, add "test" for release-1.5, and then gosec.sh needs to be removed in release-1.5 via another PR in this repo.

Release 1.4 and release 1.3 will not be bumped.