### PR TITLE
📖 fix releasing.md on annotated tags

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -80,10 +80,10 @@ We also need to create one or more tags for the Go modules ecosystem:
 
 - For any subdirectory with `go.mod` in it (excluding `hack/tools`), create
   another Git tag with directory prefix, ie.
-  `git tag -s api/v1.x.y -m api/v1.x.y`.
-  **NOTE**: Do not create annotated tags for Go modules. Release notes expects
-  only the main tag to be annotated, otherwise it might create incorrect
-  release notes.
+  `git tag -s api/v1.x.y`.
+  **NOTE**: Do not create annotated tags (`-a` or `-m`) for Go modules. Release
+  notes expects only the main tag to be annotated, otherwise it might create
+  incorrect release notes.
 
 ### Release artifacts
 


### PR DESCRIPTION
-m also implies -a, so neither of them can be present.
