### PR TITLE
🌱 Bumping CAPI to 1.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.19.9@sha256:86af5649fa1d9265d3fe7caf633231340b93e4164b96e14bc4e1131a191c1ddd
+ARG BUILD_IMAGE=docker.io/golang:1.20.8@sha256:6b29720c5598cb40b23dd38f522050a698d427c3a5696c5efe1ed22bd45b1396
 ARG BASE_IMAGE=gcr.io/distroless/static@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f  # nonroot
 
 # Build the manager binary on golang image

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -81,7 +81,7 @@ kustomize build "${SOURCE_DIR}/ippool" | "$ENVSUBST" > "${IPPOOL_GENERATED_FILE}
 echo "Generated ${IPPOOL_GENERATED_FILE}"
 
 # Get Cert-manager provider components file
-curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/cert-manager/cert-manager/releases/download/v1.12.3/cert-manager.yaml
+curl --fail -Ss -L -o "${COMPONENTS_CERT_MANAGER_GENERATED_FILE}" https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
 echo "Downloaded ${COMPONENTS_CERT_MANAGER_GENERATED_FILE}"
 
 # Generate Cluster API provider components file.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/component-base v0.26.1
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
-	sigs.k8s.io/cluster-api v1.4.6
+	sigs.k8s.io/cluster-api v1.4.7
 	sigs.k8s.io/controller-runtime v0.14.5
 
 )

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/cluster-api v1.4.6 h1:ZOAtQsPW7zh2iY7RdvvUozPR7OYRDCPSFEBS0979Vys=
-sigs.k8s.io/cluster-api v1.4.6/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
+sigs.k8s.io/cluster-api v1.4.7 h1:24UFXLDy6eiL37wquWSofKJAmFP691PLKBIA9VSUX2A=
+sigs.k8s.io/cluster-api v1.4.7/go.mod h1:B+QIe/B4Yp+NqMSd6f36Oh+7pIgalsClAX976rIn9J0=
 sigs.k8s.io/controller-runtime v0.14.5 h1:6xaWFqzT5KuAQ9ufgUaj1G/+C4Y1GRkhrxl+BJ9i+5s=
 sigs.k8s.io/controller-runtime v0.14.5/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -32,7 +32,7 @@ EOF
     local go_version
     IFS=" " read -ra go_version <<< "$(go version)"
     local minimum_go_version
-    minimum_go_version=go1.19
+    minimum_go_version=go1.20
     if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
         cat << EOF
 Detected go version: ${go_version[*]}.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Bump CAPI to v1.4.7
- Bump Cert-manager to v1.13.0
- Bump GO to 1.20.8