### PR TITLE
🌱 fix hack/verify-release.sh module list printout

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -71,7 +71,6 @@ declare -a git_annotated_tags=(
 
 declare -a git_lightweight_tags=(
     "api/v${VERSION}"
-    "test/v${VERSION}"
 )
 
 declare -a git_nonexisting_tags=(
@@ -501,10 +500,8 @@ verify_module_group_versions()
             if _module_counts_differ "${module}" "${ver}"; then
                 echo "ERROR: module ${module} has version mismatch!"
                 # print the mismatches
-                {
-                    grep --exclude=hack/tools/go.mod "\b(${mod}|${module}) v" ./**/go.mod \
-                        | grep -v "//\s*indirect"
-                } | sort | uniq
+                grep -E --exclude=hack/tools/go.mod "\b(${mod}|${module}) v" ./**/go.mod \
+                    | grep -v "//\s*indirect" | sort | uniq
                 echo
             fi
         done


### PR DESCRIPTION
Fix missing "grep -E", and remove unneeded curlys after an grep optimization.

This issue is fixed in #340 and #341 cherry-picks already.