### PR TITLE
🌱 drop test tag from verify-release.sh

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -71,7 +71,6 @@ declare -a git_annotated_tags=(
 
 declare -a git_lightweight_tags=(
     "api/v${VERSION}"
-    "test/v${VERSION}"
 )
 
 declare -a git_nonexisting_tags=(


### PR DESCRIPTION
IPAM has test directory but no test module, drop it from the checks.
