### PR TITLE
Fix multi-architecture images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build architecture
+ARG ARCH
+
 # Support FROM override
 ARG BUILD_IMAGE=docker.io/golang:1.20.8@sha256:6b29720c5598cb40b23dd38f522050a698d427c3a5696c5efe1ed22bd45b1396
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot-${ARCH}
 
 # Build the manager binary on golang image
 FROM $BUILD_IMAGE as builder


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`docker-build-all` cannot build multi-architecture images (https://quay.io/repository/metal3-io/ip-address-manager?tab=tags).

Reference CAPI multi-architecture images build: https://github.com/kubernetes-sigs/cluster-api/blob/main/Dockerfile

Original images:
<img width="1197" alt="image" src="https://github.com/metal3-io/ip-address-manager/assets/19967151/0b960c17-e297-4796-8555-e395e9006ad6">

New images:
<img width="1211" alt="image" src="https://github.com/metal3-io/ip-address-manager/assets/19967151/6d6ac232-7e3d-429b-a93c-71c6665f5e06">

