### PR TITLE
🌱 Bump golang to 1.20.11 for release-1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,13 @@ tilt-settings.json
 tilt_config.json
 tilt.d/*
 
+# Common editor / temporary files
+*~
+*.tmp
+.DS_Store
+
+go.work
+go.work.sum
+
 out
 releasenotes

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.20.10@sha256:098d628490c97d4419ed44a23d893f37b764f3bea06e0827183e8af4120e19be
+ARG BUILD_IMAGE=docker.io/golang:1.20.11@sha256:77e4e426190723821471a946a4bdad2d75d9af8209b2841f26744fe766e88444
 ARG BASE_IMAGE=gcr.io/distroless/static@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f  # nonroot
 
 # Build the manager binary on golang image


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Bump golang version to 1.20.11 which will fix security vulnerability [CVE-2023-45284](https://osv.dev/vulnerability/GO-2023-2186)
In addition, to go bump, this PR also adds `go.work` related files and some editor related temp files in gitignore.
