### PR TITLE
🌱 Use k8s apimachinery scheme builder instead of controller-runtime scheme builder

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -23,23 +23,29 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ipam.metal3.io", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	/// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
 
-	// localSchemeBuilder is for automatically generated conversions.
-	// localSchemeBuilder = SchemeBuilder.SchemeBuilder.
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
 
 // Resource is required by pkg/client/listers/...
 // func Resource(resource string) schema.GroupResource {

--- a/api/v1alpha1/ipaddress_types.go
+++ b/api/v1alpha1/ipaddress_types.go
@@ -73,5 +73,5 @@ type IPAddressList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IPAddress{}, &IPAddressList{})
+	objectTypes = append(objectTypes, &IPAddress{}, &IPAddressList{})
 }

--- a/api/v1alpha1/ipclaim_types.go
+++ b/api/v1alpha1/ipclaim_types.go
@@ -69,5 +69,5 @@ type IPClaimList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IPClaim{}, &IPClaimList{})
+	objectTypes = append(objectTypes, &IPClaim{}, &IPClaimList{})
 }

--- a/api/v1alpha1/ippool_types.go
+++ b/api/v1alpha1/ippool_types.go
@@ -116,5 +116,5 @@ type IPPoolList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IPPool{}, &IPPoolList{})
+	objectTypes = append(objectTypes, &IPPool{}, &IPPoolList{})
 }

--- a/api/v1alpha1/v1alpha4_suite_test.go
+++ b/api/v1alpha1/v1alpha4_suite_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 	}
 
-	err := SchemeBuilder.AddToScheme(scheme.Scheme)
+	err := schemeBuilder.AddToScheme(scheme.Scheme)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is recommend for the CAPI providers as mentioned the v1.5 to v1.6 migration guide: https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.5-to-v1.6#suggested-changes-for-providers.

The original issue was discussed in https://github.com/kubernetes-sigs/cluster-api/issues/9011. The issue is using controller-runtime based scheme builder causes a lot of unnecessary dependancies added in go modules. Compared to that apimachinery was chosen as a better alternative. 

Relevant CAPM3 PR# https://github.com/metal3-io/cluster-api-provider-metal3/pull/1360 