### PR TITLE
🌱 reduce github action permissions

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -2,27 +2,31 @@ name: build-images-action
 on:
   push:
     branches:
-      - 'main'
-      - 'release-*'
+    - 'main'
+    - 'release-*'
+
 permissions: {}
+
 jobs:
   build:
     name: Build container images
     runs-on: ubuntu-latest
-    if: github.repository == 'metal3-io/ip-address-manager'
+
     permissions:
       contents: read
+
+    if: github.repository == 'metal3-io/ip-address-manager'
     steps:
-      - name: build ipam image
-        uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
-        with:
-          jenkins_url: "https://jenkins.nordix.org/"
-          jenkins_user: "metal3.bot@gmail.com"
-          jenkins_token: ${{ secrets.JENKINS_TOKEN }}
-          job_name: "metal3_ip-address-manager_container_image_building"
-          job_params: |
-            {
-              "BUILD_CONTAINER_IMAGE_NAME": "ip-address-manager",
-              "BUILD_CONTAINER_IMAGE_BRANCH": "${{ github.ref }}"
-            }
-          job_timeout: "1000"
+    - name: build ipam image
+      uses: toptal/jenkins-job-trigger-action@137fff703dd260b52b53d3ba1960396415abc568 # 1.0.2
+      with:
+        jenkins_url: "https://jenkins.nordix.org/"
+        jenkins_user: "metal3.bot@gmail.com"
+        jenkins_token: ${{ secrets.JENKINS_TOKEN }}
+        job_name: "metal3_ip-address-manager_container_image_building"
+        job_params: |
+          {
+            "BUILD_CONTAINER_IMAGE_NAME": "ip-address-manager",
+            "BUILD_CONTAINER_IMAGE_BRANCH": "${{ github.ref }}"
+          }
+        job_timeout: "1000"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,19 +3,24 @@ name: dependabot
 on:
   pull_request:
     branches:
-      - dependabot/**
+    - dependabot/**
   push:
     branches:
-      - dependabot/**
+    - dependabot/**
   workflow_dispatch:
 
-permissions:
-  contents: write # Allow to update the PR.
+permissions: {}
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    if: github.repository == 'metal3-io/ip-address-manager'
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -23,10 +28,10 @@ jobs:
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
     - name: Set up Go
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # tag=v5.0.0
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
-    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # tag=v3.3.2
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       name: Restore go cache
       with:
         path: |
@@ -39,7 +44,7 @@ jobs:
       run: make modules
     - name: Update generated code
       run: make generate
-    - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # tag=v9.1.3
+    - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # v9.1.3
       name: Commit changes
       with:
         author_name: dependabot[bot]

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,30 +4,31 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-# Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
         working-directory:
-          - ""
-          - api
+        - ""
+        - api
+
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Calculate go version
-        id: vars
-        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
-      - name: Set up Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version: ${{ steps.vars.outputs.go_version }}
-      - name: golangci-lint-${{matrix.working-directory}}
-        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
-        with:
-          version: v1.54.2
-          working-directory: ${{matrix.working-directory}}
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - name: golangci-lint-${{matrix.working-directory}}
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+      with:
+        version: v1.54.2
+        working-directory: ${{matrix.working-directory}}

--- a/.github/workflows/kubesec.yml
+++ b/.github/workflows/kubesec.yml
@@ -1,64 +1,67 @@
 name: Kubesec
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   schedule:
-    - cron: '30 7 * * 1'
+  - cron: '30 7 * * 1'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   setup:
-    # This workflow is only of value to the metal3-io/ip-address-manager repository and
-    # would always fail in forks
-    if: github.repository == 'metal3-io/ip-address-manager'
     runs-on: ubuntu-20.04
+    name: setup
+
     permissions:
       actions: read
       contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Collect all yaml
-        id: list_yaml
-        run: |
-          LIST_YAML="$(find * -type f -name '*.yaml')"
-          echo "::set-output name=value::$(IFS=$','; echo $LIST_YAML | jq -cnR '[inputs | select(length>0)]'; IFS=$'\n')"
+    if: github.repository == 'metal3-io/ip-address-manager'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Collect all yaml
+      id: list_yaml
+      run: |
+        LIST_YAML="$(find * -type f -name '*.yaml')"
+        echo "::set-output name=value::$(IFS=$','; echo $LIST_YAML | jq -cnR '[inputs | select(length>0)]'; IFS=$'\n')"
     outputs:
       matrix: ${{ steps.list_yaml.outputs.value }}
 
   lint:
-    needs: [ setup ]
+    needs: [setup]
     name: Kubesec
     runs-on: ubuntu-20.04
+
     permissions:
       actions: read
       contents: read
       security-events: write
+
     strategy:
       matrix:
         value: ${{ fromJson(needs.setup.outputs.matrix) }}
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Run kubesec scanner
-        uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14
-        with:
-          input: ${{ matrix.value }}
-          format: template
-          template: template/sarif.tpl
-          output: ${{ matrix.value }}.sarif
-          exit-code: "0"
+    - name: Run kubesec scanner
+      uses: controlplaneio/kubesec-action@43d0ddff5ffee89a6bb9f29b64cd865411137b14 # v0.0.2
+      with:
+        input: ${{ matrix.value }}
+        format: template
+        template: template/sarif.tpl
+        output: ${{ matrix.value }}.sarif
+        exit-code: "0"
 
-      - name: Save result into a variable
-        id: save_result
-        run: echo "::set-output name=result::$(cat ${{ matrix.value }}.sarif | jq -c '.runs')"
+    - name: Save result into a variable
+      id: save_result
+      run: echo "::set-output name=result::$(cat ${{ matrix.value }}.sarif | jq -c '.runs')"
 
-      - name: Upload Kubesec scan results to GitHub Security tab
-        if: ${{ steps.save_result.outputs.result != '[]' }}
-        uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4
-        with:
-          sarif_file: ${{ matrix.value }}.sarif
+    - name: Upload Kubesec scan results to GitHub Security tab
+      if: ${{ steps.save_result.outputs.result != '[]' }}
+      uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4
+      with:
+        sarif_file: ${{ matrix.value }}.sarif

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -4,18 +4,19 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     paths:
-      - '**.md'
+    - '**.md'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   markdown-link-check:
     name: Broken Links
-    # This workflow is only of value to the metal3-io repository and
-    # would always fail in forks
-    if: github.repository == 'metal3-io/ip-address-manager'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    if: github.repository == 'metal3-io/ip-address-manager'
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -4,13 +4,17 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  checks: write
+permissions: {}
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     name: verify PR contents
+
+    permissions:
+      checks: write
+
+    if: github.repository == 'metal3-io/ip-address-manager'
     steps:
     - name: Verifier action
       id: verifier

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,39 +1,39 @@
+name: release
+
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
     - "v*"
 
-name: release
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    name: make-release
+
     permissions:
       contents: write
-    # This workflow is only of value to the metal3-io/ip-address-manager repository and
-    # would always fail in forks
+
     if: github.repository == 'metal3-io/ip-address-manager'
-    runs-on: ubuntu-latest
     steps:
-      - name: Export RELEASE_TAG var
-        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
-      - name: checkout code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Install go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version: '1.20'
-      - name: Generate release artifacts and notes
-        run: |
-          make release
-      - name: Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          draft: true
-          files: out/*
-          body_path: releasenotes/releasenotes.md
+    - name: Export RELEASE_TAG var
+      run: echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+    - name: checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+    - name: Install go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: '1.20'
+    - name: Generate release artifacts and notes
+      run: |
+        make release
+    - name: Release
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+      with:
+        draft: true
+        files: out/*
+        body_path: releasenotes/releasenotes.md


### PR DESCRIPTION
`contents: write` is excessive right for dependabot, as we don't allow dependabot to auto-merge anything. It is enough for it to read contents and create pull request.

Move permissions from top-level to job-level as well.

Cleanup actions formatting to be the same for easier reading and maintenance. Add missing version tags.

These is highlighted by the CLOmonitor/OpenSSF Scorecard. This restores score for token permissions to 10/10.
