### PR TITLE
🌱 fix dependabot workflow permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
-      pull-requests: write
+      contents: write
 
     steps:
     - name: Check out code into the Go module directory


### PR DESCRIPTION
Dependabot itself wouldn't need more than pull-requests: write, but we have added on generated code part which does need to write contents on top of the PR, so restoring the permissions.

Symptoms are seen in #414 
