### PR TITLE
⚠️ Changes to make IPAM deployable with CAPI

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,9 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Adds namespace to all resources. Keep it in capm3-system, as it is a
-# dependency for CAPM3
-namespace: capm3-system
+# Adds namespace to all resources
+namespace: ipam-provider-m3-system
 
 namePrefix: ipam-
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - manager.yaml
+- namespace.yaml
 
 generatorOptions:
  disableNameSuffixHash: true

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -23,7 +23,7 @@ OUTPUT_DIR=${OUTPUT_DIR:-${SOURCE_DIR}/_out}
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export NAMESPACE="${NAMESPACE:-capm3-system}"
+export NAMESPACE="${NAMESPACE:-ipam-provider-m3-system}"
 
 # Outputs.
 COMPONENTS_CERT_MANAGER_GENERATED_FILE=${OUTPUT_DIR}/cert-manager.yaml

--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ipam-controller-manager
-  namespace: capm3-system
+  namespace: ipam-provider-m3-system
 spec:
   template:
     spec:


### PR DESCRIPTION
These changes allow metal3 ip-address-manager(IPAM) to be deployed with cluster-api (CAPI). Currently deploying IPAM with CAPI assumes the CRDs are in a git release and the release has a metadata.yaml.  IPAM's current release doesn't have a metadata.yaml so this need to be added. Action need to be taken to get IPAM as an ipam-provider for CAPI so that metal3IPAM can be specified when running clusterctl init with the --ipam flag. 

IPAM's ipam-components.yaml has CRDs for ipClaim and ipAddresses which work but IPAM is unable to resolve the ipAddresClaims that CAPI has defined. This is a next step after these changes are
meged to make IPAM resolve CAPI's ipAddressClaims. Check more in [CAPI ipam contract](https://github.com/kubernetes-sigs/cluster-api/pull/10108/commits/390031158f82d31577e7fe28732670971f173f6d)
