### PR TITLE
🌱 Improve ipv6 address in bound check performance in ippool webhook

### DIFF
--- a/api/v1alpha1/ippool_webhook_test.go
+++ b/api/v1alpha1/ippool_webhook_test.go
@@ -73,6 +73,7 @@ func TestIPPoolValidation(t *testing.T) {
 func TestIPPoolUpdateValidation(t *testing.T) {
 	startAddr := IPAddressStr("192.168.0.1")
 	endAddr := IPAddressStr("192.168.0.10")
+	subnet := IPSubnetStr("192.168.0.1/25")
 
 	tests := []struct {
 		name          string
@@ -104,7 +105,7 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 			},
 		},
 		{
-			name:      "should succeed when preAllocations are correct",
+			name:      "should succeed when preAllocations are between start and end",
 			expectErr: false,
 			newPoolSpec: &IPPoolSpec{
 				NamePrefix: "abcd",
@@ -125,7 +126,7 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 			},
 		},
 		{
-			name:      "should fail when preAllocations are incorrect",
+			name:      "should fail when preAllocations are out of start and end",
 			expectErr: true,
 			newPoolSpec: &IPPoolSpec{
 				NamePrefix: "abcd",
@@ -134,6 +135,48 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 				},
 				PreAllocations: map[string]IPAddressStr{
 					"alloc": IPAddressStr("192.168.0.20"),
+				},
+			},
+			oldPoolSpec: &IPPoolSpec{
+				NamePrefix: "abcd",
+			},
+			oldPoolStatus: IPPoolStatus{
+				Allocations: map[string]IPAddressStr{
+					"inuse": IPAddressStr("192.168.0.3"),
+				},
+			},
+		},
+		{
+			name:      "should succeed when preAllocations are in the cidr",
+			expectErr: false,
+			newPoolSpec: &IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []Pool{
+					{Subnet: &subnet},
+				},
+				PreAllocations: map[string]IPAddressStr{
+					"alloc": IPAddressStr("192.168.0.2"),
+				},
+			},
+			oldPoolSpec: &IPPoolSpec{
+				NamePrefix: "abcd",
+			},
+			oldPoolStatus: IPPoolStatus{
+				Allocations: map[string]IPAddressStr{
+					"inuse": IPAddressStr("192.168.0.3"),
+				},
+			},
+		},
+		{
+			name:      "should fail when preAllocations are out of cidr",
+			expectErr: true,
+			newPoolSpec: &IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []Pool{
+					{Subnet: &subnet},
+				},
+				PreAllocations: map[string]IPAddressStr{
+					"alloc": IPAddressStr("192.168.0.250"),
 				},
 			},
 			oldPoolSpec: &IPPoolSpec{


### PR DESCRIPTION
What this PR does / why we need it:

Cherry-pick form main to get the fix into release 1.6

The current mechanism of checking if an ip address is within the bound of a given ippool loops through the domain of all ip addresses in the ip pool one by one. A subnet in ipv6 can easily be a very large cidr that involves millions or billions of addresses. The validation webhook could time out (default 10 seconds) before the check is complete, if the ip address being checked is at the end of the cidr range or even out of the range at all.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes https://github.com/metal3-io/ip-address-manager/issues/430