### PR TITLE
🌱 add support for beta/rc releases in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ permissions: {}
 
 jobs:
   build:
+    name: tag release
     runs-on: ubuntu-latest
-    name: make-release
 
     permissions:
       contents: write
@@ -36,4 +36,4 @@ jobs:
       with:
         draft: true
         files: out/*
-        body_path: releasenotes/releasenotes.md
+        body_path: releasenotes/${{ env.RELEASE_TAG }}.md

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-api: ## Builds api directory.
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
 
-$(GOLANGCI_LINT): 
+$(GOLANGCI_LINT):
 		hack/ensure-golangci-lint.sh $(TOOLS_DIR)/$(BIN_DIR)
 
 $(MOCKGEN): $(TOOLS_DIR)/go.mod # Build mockgen from tools folder.
@@ -288,7 +288,7 @@ kind-reset: ## Destroys the "ipam" kind cluster.
 RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 RELEASE_DIR := out
 RELEASE_NOTES_DIR := releasenotes
-PREVIOUS_TAG ?= $(shell git tag -l | grep -B 1 $(RELEASE_TAG) | head -n 1)
+PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+" | sort -V | grep -B1 $(RELEASE_TAG) | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | head -n 1 2>/dev/null)
 
 $(RELEASE_DIR):
 	mkdir -p $(RELEASE_DIR)/
@@ -302,7 +302,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
-	go run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/releasenotes.md
+	go run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 .PHONY: release
 release:

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -45,6 +45,10 @@ const (
 	superseded    = ":recycle: Superseded or Reverted"
 )
 
+const (
+	warningTemplate = ":rotating_light: This is a %s. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/metal3-io/ip-address-manager/issues/new/).\n\n"
+)
+
 var (
 	outputOrder = []string{
 		warning,
@@ -85,6 +89,14 @@ func lastTag() string {
 	return string(bytes.TrimSpace(out))
 }
 
+func isBeta(tag string) bool {
+	return strings.Contains(tag, "-beta.")
+}
+
+func isRC(tag string) bool {
+	return strings.Contains(tag, "-rc.")
+}
+
 func firstCommit() string {
 	cmd := exec.Command("git", "rev-list", "--max-parents=0", "HEAD")
 	out, err := cmd.Output()
@@ -97,7 +109,7 @@ func firstCommit() string {
 func run() int {
 	lastTag := lastTag()
 	latestTag := latestTag()
-	cmd := exec.Command("git", "rev-list", lastTag+"..HEAD", "--merges", "--pretty=format:%B")
+	cmd := exec.Command("git", "rev-list", lastTag+"..HEAD", "--merges", "--pretty=format:%B") // #nosec G204:gosec
 
 	merges := map[string][]string{
 		features:      {},
@@ -174,12 +186,15 @@ func run() int {
 		merges[key] = append(merges[key], formatMerge(body, prNumber))
 	}
 
-	// Add empty superseded section
-	merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+	// Add empty superseded section, if not beta/rc, we don't cleanup those notes
+	if !isBeta(latestTag) && !isRC(latestTag) {
+		merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
+	}
 
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Printf("Changes since %v\n---\n", lastTag)
 
+	// print the changes by category
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
 		if len(mergeslice) > 0 {
@@ -189,10 +204,29 @@ func run() int {
 			}
 			fmt.Println()
 		}
+
+		// if we're doing beta/rc, print breaking changes and hide the rest of the changes
+		if key == warning {
+			if isBeta(latestTag) {
+				fmt.Printf(warningTemplate, "BETA RELEASE")
+			}
+			if isRC(latestTag) {
+				fmt.Printf(warningTemplate, "RELEASE CANDIDATE")
+			}
+			if isBeta(latestTag) || isRC(latestTag) {
+				fmt.Printf("<details>\n")
+				fmt.Printf("<summary>More details about the release</summary>\n\n")
+			}
+		}
 	}
 
-	fmt.Printf("The container image for this release is: %v\n", latestTag)
-	fmt.Println("\nThanks to all our contributors! 😊")
+	// then close the details if we had it open
+	if isBeta(latestTag) || isRC(latestTag) {
+		fmt.Printf("</details>\n\n")
+	}
+
+	fmt.Printf("The image for this release is: %v\n", latestTag)
+	fmt.Println("\n_Thanks to all our contributors!_ 😊")
 
 	return 0
 }


### PR DESCRIPTION
Support beta and RC releases in release note generator. Move some logic from Makefile to the release note generator, and then add nice unfolding summary section to hide details in beta/rc notes.

Fix previous release tag pattern detection in Makefile, and make the release note file named after the tag, same as CAPM3.

Example output visible in CAPM3 PR: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1567
