### PR TITLE
🌱 Set ARCH based on go env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ PROD_REGISTRY := quay.io/metal3-io
 IMAGE_NAME ?= ip-address-manager
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= v1alpha1
-ARCH ?= amd64
+ARCH ?= $(shell go env GOARCH)
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 # Allow overriding manifest generation destination directory


### PR DESCRIPTION
**What this PR does / why we need it**:

We had ARCH hard-coded to amd64. This commit changes it so that we take it from go env instead. That way we should automatically get the proper architechture on different devices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #517 
