### PR TITLE
🌱 add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- kashifest
-- lentzi90
-- Rozzii
-- Sunnatillo
-- tuminoid
+- ip-address-manager-maintainers
 
 reviewers:
-- mquhuy
-- smoshiur1237
-
+- ip-address-manager-maintainers
+- ip-address-manager-reviewers
 
 emeritus_approvers:
 - fmuyassarov

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ip-address-manager-maintainers:
+  - kashifest
+  - lentzi90
+  - Rozzii
+  - Sunnatillo
+  - tuminoid
+
+  ip-address-manager-reviewers:
+  - mquhuy
+  - smoshiur1237


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.
