### PR TITLE
🌱 Optimize the dependabot configuration and add release branch configurations.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,42 +3,33 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: ":seedling:"
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+  commit-message:
+    prefix: ":seedling:"
     # Go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-    commit-message:
-      prefix: ":seedling:"
-  - package-ecosystem: "gomod"
-    directory: "/api"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # Ignore controller-runtime as its upgraded manually.
-      - dependency-name: "sigs.k8s.io/controller-runtime"
-      # Ignore k8s and its transitives modules as they are upgraded manually
-      # together with controller-runtime.
-      - dependency-name: "k8s.io/*"
-    commit-message:
-      prefix: ":seedling:"
-  - package-ecosystem: "gomod"
-    directory: "/hack/tools"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "sigs.k8s.io/controller-tools"
-    commit-message:
-      prefix: ":seedling:"
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/api"
+  - "/hack/tools"
+  schedule:
+    interval: "weekly"
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-tools"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,12 @@
 
 version: 2
 updates:
+## main branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+  target-branch: main
   commit-message:
     prefix: ":seedling:"
     # Go
@@ -17,6 +19,7 @@ updates:
   - "/hack/tools"
   schedule:
     interval: "weekly"
+  target-branch: main
   groups:
     kubernetes:
       patterns: ["k8s.io/*"]
@@ -33,3 +36,72 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+    ## main branch config ends here
+    ## release-1.7 branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+  target-branch: release-1.7
+  commit-message:
+    prefix: ":seedling:"
+  ignore:
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    # Go
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/api"
+  - "/hack/tools"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.7
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+    ## release-1.7 branch config ends here
+    ## release-1.6 branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+  target-branch: release-1.6
+  commit-message:
+    prefix: ":seedling:"
+  ignore:
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    # Go
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/api"
+  - "/hack/tools"
+  schedule:
+    interval: "weekly"
+  target-branch: release-1.6
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+  ignore:
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  ## release-1.6 branch config ends here


### PR DESCRIPTION
This PR add the following:

- Adds newly introduced multi-directories feature in dependabot. With this hopefully all the go modules would be bumped in one PR for a dependancy. Also this PR optimizes the dependabot configs a bit by adding a group for k8s.io dependancy bump and allowing patch versions for the ignore rules.
- Also add release branch configurations for dependabot