### PR TITLE
🌱 Bump golang to v1.22

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: Generate release artifacts and notes
       run: |
         make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,87 +1,87 @@
 run:
   deadline: 5m
   skip-dirs:
-    - mock*
+  - mock*
   skip-files:
   - "zz_generated.*\\.go$"
   - ".*conversion.*\\.go$"
 linters:
   disable-all: true
   enable:
-    - asciicheck
-    - bodyclose
-    - dogsled
-    - errcheck
-    - errorlint
-    - exportloopref
-    - goconst
-    - gocritic
-    - godot
-    - gofmt
-    - goimports
-    - gosimple
-    - govet
-    - importas
-    - gosec
-    - ineffassign
-    - misspell
-    - nakedret
-    - nilerr
-    - noctx
-    - nolintlint
-    - prealloc
-    - predeclared
-    - revive
-    - rowserrcheck
-    - staticcheck
-    - stylecheck
-    - thelper
-    - typecheck
-    - unconvert
-    - unused
-    - whitespace
+  - asciicheck
+  - bodyclose
+  - dogsled
+  - errcheck
+  - errorlint
+  - exportloopref
+  - goconst
+  - gocritic
+  - godot
+  - gofmt
+  - goimports
+  - gosimple
+  - govet
+  - importas
+  - gosec
+  - ineffassign
+  - misspell
+  - nakedret
+  - nilerr
+  - noctx
+  - nolintlint
+  - prealloc
+  - predeclared
+  - revive
+  - rowserrcheck
+  - staticcheck
+  - stylecheck
+  - thelper
+  - typecheck
+  - unconvert
+  - unused
+  - whitespace
   # Run with --fast=false for more extensive checks
   fast: true
 
 linters-settings:
   gosec:
-    go: "1.21"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
   importas:
-      no-unaliased: true
-      alias:
-        # Kubernetes
-        - pkg: k8s.io/api/core/v1
-          alias: corev1
-        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-          alias: apiextensionsv1
-        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-          alias: metav1
-        - pkg: k8s.io/apimachinery/pkg/api/errors
-          alias: apierrors
-        # Controller Runtime
-        - pkg: sigs.k8s.io/controller-runtime
-          alias: ctrl
-        - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
-          alias: clusterv1alpha4
-        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
-          alias: clusterv1
-        # IPAM
-        - pkg: github.com/metal3-io/ip-address-manager/api/v1alpha1
-          alias: ipamv1
+    no-unaliased: true
+    alias:
+    # Kubernetes
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+      alias: apiextensionsv1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    # Controller Runtime
+    - pkg: sigs.k8s.io/controller-runtime
+      alias: ctrl
+    - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
+      alias: clusterv1alpha4
+    - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+      alias: clusterv1
+    # IPAM
+    - pkg: github.com/metal3-io/ip-address-manager/api/v1alpha1
+      alias: ipamv1
   nolintlint:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.21"
+    go: "1.22"
   stylecheck:
-    go: "1.21"
+    go: "1.22"
   gocritic:
     enabled-tags:
-      - experimental
+    - experimental
     disabled-checks:
     - appendAssign
     - dupImport # https://github.com/go-critic/go-critic/issues/845
@@ -97,55 +97,55 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.21"
+    go: "1.22"
 issues:
   exclude-rules:
-    - path: _test\.go
-      linters:
-        - unused
-    # Disable linters for conversion
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-      path: .*(api|types)\/.*\/conversion.*\.go$
-    # Dot imports for gomega or ginkgo are allowed
-    # within test files.
-    - path: _test\.go
-      text: should not use dot imports
-    - path: (test|e2e)/.*.go
-      text: should not use dot imports
-    - linters:
-      - revive
-      text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-    # Exclude some packages or code to require comments, for example test code, or fake clients.
-    - linters:
-      - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      source: (func|type).*Fake.*
-    - linters:
-      - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      path: fake_\.go
-    - linters:
-      - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      path: .*(api|types)\/.*\/conversion.*\.go$
-    - linters:
-      - revive
-      text: "var-naming: don't use underscores in Go names;"
-      path: .*(api|types)\/.*\/conversion.*\.go$
-    - linters:
-      - revive
-      text: "receiver-naming: receiver name"
-      path: .*(api|types)\/.*\/conversion.*\.go$
-    - linters:
-      - stylecheck
-      text: "ST1003: should not use underscores in Go names;"
-      path: .*(api|types)\/.*\/conversion.*\.go$
-    - linters:
-      - stylecheck
-      text: "ST1016: methods on the same type should have the same receiver name"
-      path: .*(api|types)\/.*\/conversion.*\.go$
+  - path: _test\.go
+    linters:
+    - unused
+  # Disable linters for conversion
+  - linters:
+    - staticcheck
+    text: "SA1019:"
+    path: .*(api|types)\/.*\/conversion.*\.go$
+  # Dot imports for gomega or ginkgo are allowed
+  # within test files.
+  - path: _test\.go
+    text: should not use dot imports
+  - path: (test|e2e)/.*.go
+    text: should not use dot imports
+  - linters:
+    - revive
+    text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
+  # Exclude some packages or code to require comments, for example test code, or fake clients.
+  - linters:
+    - revive
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    source: (func|type).*Fake.*
+  - linters:
+    - revive
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    path: fake_\.go
+  - linters:
+    - revive
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    path: .*(api|types)\/.*\/conversion.*\.go$
+  - linters:
+    - revive
+    text: "var-naming: don't use underscores in Go names;"
+    path: .*(api|types)\/.*\/conversion.*\.go$
+  - linters:
+    - revive
+    text: "receiver-naming: receiver name"
+    path: .*(api|types)\/.*\/conversion.*\.go$
+  - linters:
+    - stylecheck
+    text: "ST1003: should not use underscores in Go names;"
+    path: .*(api|types)\/.*\/conversion.*\.go$
+  - linters:
+    - stylecheck
+    text: "ST1016: methods on the same type should have the same receiver name"
+    path: .*(api|types)\/.*\/conversion.*\.go$
   include:
   - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.9@sha256:7d0dcbe5807b1ad7272a598fbf9d7af15b5e2bed4fd6c4c2b5b3684df0b317dd
+ARG BUILD_IMAGE=docker.io/golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.21.9
+GO_VERSION ?= 1.22.3
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/ip-address-manager/api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/onsi/ginkgo/v2 v2.17.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/ip-address-manager
 
-go 1.21
+go 1.22
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -34,6 +34,6 @@ else
         --volume "${PWD}:/workdir:rw,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/codegen.sh
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/metal3-io/ip-address-manager/hack/tools
 
-go 1.21
+go 1.22
 
 require (
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.21 \
+        docker.io/golang:1.22 \
         /workdir/hack/unit.sh "$@"
 fi


### PR DESCRIPTION
This PR bumps golang to v1.22.3 in Dockerfile, gomodules and container images for different tests in hack/ directory
