### PR TITLE
🌱 schedule dependabot on certain day, and add ok-to-test automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,13 @@ updates:
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "monday"
   target-branch: main
   commit-message:
     prefix: ":seedling:"
-    # Go
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -19,6 +22,7 @@ updates:
   - "/hack/tools"
   schedule:
     interval: "weekly"
+    day: "tuesday"
   target-branch: main
   groups:
     kubernetes:
@@ -36,20 +40,25 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
-    ## main branch config ends here
-    ## release-1.7 branch config starts here
+  labels:
+  - "ok-to-test"
+## main branch config ends here
+## release-1.7 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "monday"
   target-branch: release-1.7
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # Go
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -57,6 +66,7 @@ updates:
   - "/hack/tools"
   schedule:
     interval: "weekly"
+    day: "tuesday"
   target-branch: release-1.7
   groups:
     kubernetes:
@@ -70,20 +80,25 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
-    ## release-1.7 branch config ends here
-    ## release-1.6 branch config starts here
+  labels:
+  - "ok-to-test"
+## release-1.7 branch config ends here
+## release-1.6 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
   schedule:
     interval: "monthly"
+    day: "monday"
   target-branch: release-1.6
-  commit-message:
-    prefix: ":seedling:"
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
-    # Go
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
 - package-ecosystem: "gomod"
   directories:
   - "/"
@@ -91,6 +106,7 @@ updates:
   - "/hack/tools"
   schedule:
     interval: "weekly"
+    day: "tuesday"
   target-branch: release-1.6
   groups:
     kubernetes:
@@ -104,4 +120,6 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
   ## release-1.6 branch config ends here


### PR DESCRIPTION
IPAM schedule:
- GH actions: monday - monthly
- Gomod: tuesday - weekly

Automatically add labels:
- ok-to-test

We have dynamic Prow scheduling now and proper requests, we should not suffer from load failures in very basic tests anymore.

Fix indentation for comments, and make config consistent between each other as well.