### PR TITLE
:seedling: Bump golang to 1.22 in release 1.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.22'
       - name: Generate release artifacts and notes
         run: |
           make release

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,7 +45,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.20"
+    go: "1.22"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -76,9 +76,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.20"
+    go: "1.22"
   stylecheck:
-    go: "1.20"
+    go: "1.22"
   gocritic:
     enabled-tags:
       - experimental
@@ -97,7 +97,7 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.20"
+    go: "1.22"
 issues:
   exclude-rules:
     - path: _test\.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.21.11@sha256:a8edec58ba598e2f1259f4ec4ca1b06358468214225e73d7c841ab0980c12367
+ARG BUILD_IMAGE=docker.io/golang:1.22.5@sha256:f47a7952d08277f9816459d851319c9041637022f04517388d9f32e384fc2dab
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.21.11
+GO_VERSION ?= 1.22.5
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -92,9 +92,9 @@ var _ = Describe("IPPool controller", func() {
 			}
 
 			if tc.m3ipp != nil && !tc.m3ipp.DeletionTimestamp.IsZero() && tc.reconcileDeleteError {
-				m.EXPECT().UpdateAddresses(context.TODO()).Return(0, errors.New(""))
+				m.EXPECT().UpdateAddresses(context.Background()).Return(0, errors.New(""))
 			} else if tc.m3ipp != nil && !tc.m3ipp.DeletionTimestamp.IsZero() {
-				m.EXPECT().UpdateAddresses(context.TODO()).Return(0, nil)
+				m.EXPECT().UpdateAddresses(context.Background()).Return(0, nil)
 				m.EXPECT().UnsetFinalizer()
 			}
 
@@ -102,9 +102,9 @@ var _ = Describe("IPPool controller", func() {
 				tc.reconcileNormal {
 				m.EXPECT().SetFinalizer()
 				if tc.reconcileNormalError {
-					m.EXPECT().UpdateAddresses(context.TODO()).Return(0, errors.New(""))
+					m.EXPECT().UpdateAddresses(context.Background()).Return(0, errors.New(""))
 				} else {
-					m.EXPECT().UpdateAddresses(context.TODO()).Return(1, nil)
+					m.EXPECT().UpdateAddresses(context.Background()).Return(1, nil)
 				}
 			}
 

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -34,6 +34,6 @@ else
         --volume "${PWD}:/workdir:rw,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/codegen.sh
 fi

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/gofmt.sh
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -39,6 +39,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/govet.sh
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -17,6 +17,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/golang:1.20 \
+        docker.io/golang:1.22 \
         /workdir/hack/unit.sh "$@"
 fi


### PR DESCRIPTION
This is done since golang 1.20 is already deprecated and branch 1.6 is still supported

Fixes #597
