### PR TITLE
:seedling: Container build wf only run for upstream

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -14,9 +14,10 @@ on:
 jobs:
   build_ipam:
     name: Build IPAM container image
+    if: github.repository == 'metal3-io/ip-address-manager'
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
-      image-name: "ip-address-manager"
+      image-name: 'ip-address-manager'
       pushImage: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
The container build wf should only run for upstream repo
