### PR TITLE
🌱 Set terminationMessagePolicy to FallbackToLogsOnError for manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,43 +18,44 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-        - command:
-            - /manager
-          args:
-            - "--webhook-port=9443"
-            - "--diagnostics-address=${IPAM_DIAGNOSTICS_ADDRESS:=:8443}"
-            - "--insecure-diagnostics=${IPAM_INSECURE_DIAGNOSTICS:=false}"
-          image: controller:latest
-          imagePullPolicy: IfNotPresent
-          name: manager
-          env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          ports:
-            - containerPort: 9440
-              name: healthz
-              protocol: TCP
-            - containerPort: 8443
-              name: metrics
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: healthz
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: healthz
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            runAsUser: 65532
-            runAsGroup: 65532
+      - command:
+        - /manager
+        args:
+        - "--webhook-port=9443"
+        - "--diagnostics-address=${IPAM_DIAGNOSTICS_ADDRESS:=:8443}"
+        - "--insecure-diagnostics=${IPAM_INSECURE_DIAGNOSTICS:=false}"
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        name: manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsUser: 65532
+          runAsGroup: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true
@@ -62,9 +63,9 @@ spec:
           type: RuntimeDefault
       serviceAccountName: manager
       tolerations:
-        # TODO (fmuyassarov): remove node-role.kubernetes.io/master
-        # taint before moving to k8s v1.24
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+      # TODO (fmuyassarov): remove node-role.kubernetes.io/master
+      # taint before moving to k8s v1.24
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
This ensures we have a useful termination message in the Pod if a manager exits unexpectedly.

Check: kubernetes-sigs/cluster-api#10580

