### PR TITLE
🌱 fix verify-release.sh to understand go directive better

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -636,7 +636,7 @@ _mutate_gomod_files_for_osv_scanner()
         <(_get_golang_version_from_dockerfile)
 
     for modfile in **/go.mod; do
-        sed -i.bak -e "s/^go [[:digit:]]\.[[:digit:]]\+/go ${tag}/" "${modfile}"
+        sed -i.bak -e "s/^go .*$/go ${tag}/" "${modfile}"
     done
 }
 


### PR DESCRIPTION
Currently it fails to do the vulnerability scan if the go directive has golang patch version in it, like "1.22.3", as it replaces "1.22" with "1.22.5" it finds from Dockerfile, resulting to "1.22.5.3" which blows up.
