### PR TITLE
:seedling: Bump kustomize to v5.4.3

### DIFF
--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -2,7 +2,7 @@
 
 [[ -f bin/kustomize ]] && exit 0
 
-version=4.4.1
+version=5.4.3
 arch=$(go env GOARCH)
 os=$(go env GOOS)
 


### PR DESCRIPTION
We update kustomize syntax to v5 in this PR https://github.com/metal3-io/ip-address-manager/pull/506, but we still haven't upgraded the binary.
