### PR TITLE
⚠️ Make ip-address-manager an IPAM provider for CAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG BUILD_IMAGE=docker.io/golang:1.23.5@sha256:8c10f21bec412f08f73aa7b97ca5ac5f2
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image
-FROM $BUILD_IMAGE as builder
+FROM $BUILD_IMAGE AS builder
 WORKDIR /workspace
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy

--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,7 @@ $(RELEASE_NOTES_DIR):
 .PHONY: release-manifests
 release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publish with a release
 	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/ipam-components.yaml
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: release-notes-tool
 release-notes-tool:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Deploys IPAM CRDs and deploys IPAM controllers
 Runs IPAM controller locally
 
 ```sh
-    kubectl scale -n capm3-system \
+    kubectl scale -n metal3-ipam-system \
       deployment.v1.apps/metal3-ipam-controller-manager --replicas 0
     make run
 ```

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,16 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Adds namespace to all resources. Keep it in capm3-system, as it is a
-# dependency for CAPM3
-namespace: capm3-system
+# Adds namespace to all resources.
+namespace: metal3-ipam-system
 
 namePrefix: ipam-
 
 labels:
 - includeSelectors: true
   pairs:
-    cluster.x-k8s.io/provider: infrastructure-metal3
+    cluster.x-k8s.io/provider: ipam-metal3
 
 resources:
 - ../rbac

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,28 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims
+  - ipaddresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ipam.cluster.x-k8s.io
+  resources:
+  - ipaddressclaims/status
+  - ipaddresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - ipam.metal3.io
   resources:
   - ipaddresses

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -399,6 +400,65 @@ var _ = Describe("IPPool controller", func() {
 					ObjectMeta: testObjectMeta,
 					Spec: ipamv1.IPClaimSpec{
 						Pool: corev1.ObjectReference{
+							Name: "abc",
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+	)
+
+	type TestCaseK8SIPACToM3IPP struct {
+		IPAddressClaim *capipamv1.IPAddressClaim
+		ExpectRequest  bool
+	}
+
+	DescribeTable("IPAddressClaim To IPPool tests",
+		func(tc TestCaseK8SIPACToM3IPP) {
+			r := IPPoolReconciler{}
+			obj := client.Object(tc.IPAddressClaim)
+			reqs := r.IPAddressClaimToIPPool(context.Background(), obj)
+
+			if tc.ExpectRequest {
+				Expect(len(reqs)).To(Equal(1), "Expected 1 request, found %d", len(reqs))
+
+				req := reqs[0]
+				Expect(req.NamespacedName.Name).To(Equal(tc.IPAddressClaim.Spec.PoolRef.Name),
+					"Expected name %s, found %s", tc.IPAddressClaim.Spec.PoolRef.Name, req.NamespacedName.Name)
+			} else {
+				Expect(len(reqs)).To(Equal(0), "Expected 0 request, found %d", len(reqs))
+
+			}
+		},
+		Entry("No IPPool in Spec",
+			TestCaseK8SIPACToM3IPP{
+				IPAddressClaim: &capipamv1.IPAddressClaim{
+					ObjectMeta: testObjectMeta,
+					Spec:       capipamv1.IPAddressClaimSpec{},
+				},
+				ExpectRequest: false,
+			},
+		),
+		Entry("IPPool in Spec, with namespace",
+			TestCaseK8SIPACToM3IPP{
+				IPAddressClaim: &capipamv1.IPAddressClaim{
+					ObjectMeta: testObjectMeta,
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "abc",
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+		Entry("IPPool in Spec, no namespace",
+			TestCaseK8SIPACToM3IPP{
+				IPAddressClaim: &capipamv1.IPAddressClaim{
+					ObjectMeta: testObjectMeta,
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
 							Name: "abc",
 						},
 					},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,6 +32,7 @@ import (
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -57,6 +58,7 @@ func init() {
 	_ = apiextensionsv1.AddToScheme(scheme.Scheme)
 	_ = clusterv1.AddToScheme(scheme.Scheme)
 	_ = ipamv1.AddToScheme(scheme.Scheme)
+	_ = capipamv1.AddToScheme(scheme.Scheme)
 }
 
 func setupScheme() *runtime.Scheme {
@@ -67,6 +69,10 @@ func setupScheme() *runtime.Scheme {
 	}
 
 	if err := ipamv1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+
+	if err := capipamv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 
@@ -92,6 +98,9 @@ var _ = BeforeSuite(func() {
 		Expect(cfg).ToNot(BeNil())
 
 		err = ipamv1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = capipamv1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = apiextensionsv1.AddToScheme(scheme.Scheme)

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -23,7 +23,7 @@ OUTPUT_DIR=${OUTPUT_DIR:-${SOURCE_DIR}/_out}
 
 # Cluster.
 export CLUSTER_NAME="${CLUSTER_NAME:-test1}"
-export NAMESPACE="${NAMESPACE:-capm3-system}"
+export NAMESPACE="${NAMESPACE:-metal3-ipam-system}"
 
 # Outputs.
 COMPONENTS_CERT_MANAGER_GENERATED_FILE=${OUTPUT_DIR}/cert-manager.yaml

--- a/examples/ippool/ippool.yaml
+++ b/examples/ippool/ippool.yaml
@@ -39,3 +39,13 @@ spec:
   pool:
     name: pool1
     namespace: ${NAMESPACE}
+---
+apiVersion: ipam.cluster.x-k8s.io/v1beta1
+kind: IPAddressClaim
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template-1-provisioning-pool
+spec:
+  poolRef:
+    apiGroup: ipam.metal3.io
+    kind: IPPool
+    name: pool1

--- a/examples/provider-components/manager_tolerations_patch.yaml
+++ b/examples/provider-components/manager_tolerations_patch.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ipam-controller-manager
-  namespace: capm3-system
+  namespace: metal3-ipam-system
 spec:
   template:
     spec:

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -29,11 +29,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var notFoundErr *NotFoundError
+var (
+	notFoundErr *NotFoundError
+	APIGroup    = "ipam.metal3.io"
+)
+
+const (
+	IPAddressClaimFinalizer = "ipam.metal3.io/ipaddressclaim"
+	IPAddressFinalizer      = "ipam.metal3.io/ipaddress"
+)
 
 // IPPoolManagerInterface is an interface for a IPPoolManager.
 type IPPoolManagerInterface interface {
@@ -154,6 +163,33 @@ func (m *IPPoolManager) getIndexes(ctx context.Context) (map[ipamv1.IPAddressStr
 		addresses[addressObject.Spec.Address] = claimName
 	}
 
+	// get list of IPAddress objects for cluster.x-k8s.io addresses
+	capiAddressObjects := capipamv1.IPAddressList{}
+	err = m.client.List(ctx, &capiAddressObjects, opts)
+	if err != nil {
+		return addresses, err
+	}
+
+	// Iterate over the IPAddress objects to find all addresses and objects
+	for _, addressObject := range capiAddressObjects.Items {
+		// If IPPool does not point to this object, discard
+		if addressObject.Spec.PoolRef.Name == "" {
+			continue
+		}
+		if addressObject.Spec.PoolRef.Name != m.IPPool.Name {
+			continue
+		}
+
+		// Get the claim Name, if unset use empty string, to still record the
+		// index being used, to avoid conflicts
+		claimName := ""
+		if addressObject.Spec.ClaimRef.Name != "" {
+			claimName = addressObject.Spec.ClaimRef.Name
+		}
+		updatedAllocations[claimName] = ipamv1.IPAddressStr(addressObject.Spec.Address)
+		addresses[ipamv1.IPAddressStr(addressObject.Spec.Address)] = claimName
+	}
+
 	if !reflect.DeepEqual(updatedAllocations, m.IPPool.Status.Allocations) {
 		m.IPPool.Status.Allocations = updatedAllocations
 		m.updateStatusTimestamp()
@@ -168,8 +204,25 @@ func (m *IPPoolManager) updateStatusTimestamp() {
 }
 
 // UpdateAddresses manages the claims and creates or deletes IPAddress accordingly.
-// It returns the number of current allocations.
+// It returns the number of current allocations. Current allocation include
+// both capi and metal3 type ipaddress objects.
 func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
+	_, err := m.m3UpdateAddresses(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count, err := m.capiUpdateAddresses(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// UpdateM3Addresses manages the ipclaims.ipam.metal3.io and creates or deletes IPAddress.ipam.metal3.io accordingly.
+// It returns the number of current allocations. Current allocation include
+// both capi and metal3 type ipaddress objects.
+func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 	addresses, err := m.getIndexes(ctx)
 	if err != nil {
 		return 0, err
@@ -206,6 +259,47 @@ func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
 	return len(addresses), nil
 }
 
+// UpdateCAPIAddresses manages the ipaddressclaims.ipam.cluster.x-k8s.io and creates or deletes IPAddress.ipam.cluster.x-k8s.io accordingly.
+// It returns the number of current allocations.
+func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
+	addresses, err := m.getIndexes(ctx)
+	if err != nil {
+		return 0, err
+	}
+	// get list of IPClaim objects
+	addressClaimObjects := capipamv1.IPAddressClaimList{}
+	// without this ListOption, all namespaces would be including in the listing
+	opts := &client.ListOptions{
+		Namespace: m.IPPool.Namespace,
+	}
+
+	err = m.client.List(ctx, &addressClaimObjects, opts)
+	if err != nil {
+		return 0, err
+	}
+
+	// Iterate over the IPAddressClaim objects to find all addresses and objects
+	for _, addressClaim := range addressClaimObjects.Items {
+		// If IPPool does not point to this object, discard
+		if addressClaim.Spec.PoolRef.Name != m.IPPool.Name {
+			continue
+		}
+
+		if addressClaim.Status.AddressRef.Name != "" && addressClaim.DeletionTimestamp.IsZero() {
+			continue
+		}
+		addresses, err = m.capiUpdateAddress(ctx, &addressClaim, addresses)
+		if err != nil {
+			return 0, err
+		}
+	}
+	m.updateStatusTimestamp()
+	return len(addresses), nil
+}
+
+// UpdateAddress creates metal3 ipaddress or deletes it. Address can be deleted if it
+// doesn't have finalizers or only has the ipamv1.IPClaimFinalizer
+// Return a map where IP addresses is key and value is the associated (metal3 and/or capi) claim's name.
 func (m *IPPoolManager) updateAddress(ctx context.Context,
 	addressClaim *ipamv1.IPClaim, addresses map[ipamv1.IPAddressStr]string,
 ) (_ map[ipamv1.IPAddressStr]string, rerr error) {
@@ -252,6 +346,61 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 	return addresses, nil
 }
 
+// capiUpdateAddress creates capi ipaddress or deletes it. Address can be deleted if it
+// doesn't have finalizers or only has the ipamv1.IPClaimFinalizer
+// Return a map where IP addresses is key and value is the associated (metal3 and/or capi) claim's name.
+func (m *IPPoolManager) capiUpdateAddress(ctx context.Context,
+	addressClaim *capipamv1.IPAddressClaim, addresses map[ipamv1.IPAddressStr]string,
+) (map[ipamv1.IPAddressStr]string, error) {
+	helper, err := patch.NewHelper(addressClaim, m.client)
+	if err != nil {
+		return addresses, errors.Wrap(err, "failed to init patch helper")
+	}
+	// Always patch addressClaim exiting this function so we can persist any changes.
+	defer func() {
+		err := helper.Patch(ctx, addressClaim)
+		if err != nil {
+			m.Log.Error(err, "failed to Patch IPAddressClaim")
+		}
+	}()
+
+	conditions := clusterv1.Conditions{}
+	conditions = append(conditions, clusterv1.Condition{
+		Type:               "ErrorMessage",
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Severity:           "Info",
+		Reason:             "ErrorMessage",
+		Message:            "",
+	})
+	addressClaim.SetConditions(conditions)
+
+	if addressClaim.DeletionTimestamp.IsZero() {
+		addresses, err = m.capiCreateAddress(ctx, addressClaim, addresses)
+		if err != nil {
+			return addresses, err
+		}
+	} else {
+		// Check if this claim is in use. Does it have any other finalizers than our own?
+		// If it is no longer in use, proceed to delete the associated IPAddress
+		if len(addressClaim.Finalizers) > 1 ||
+			(len(addressClaim.Finalizers) == 1 && !Contains(addressClaim.Finalizers, IPAddressClaimFinalizer)) {
+			m.Log.Info("IPAddressClaim is still in use (has other finalizers). Cannot delete IPAddress.",
+				"IPAddressClaim", addressClaim.Name, "Finalizers", addressClaim.Finalizers)
+			return addresses, nil
+		}
+
+		addresses, err = m.capiDeleteAddress(ctx, addressClaim, addresses)
+		if err != nil {
+			return addresses, err
+		}
+	}
+	return addresses, nil
+}
+
+// allocateAddress gets an (metal3)IpAddress for a (metal3)IPClaim.
+// it takes into consideration the possible preallocations.
+// Returns an IP address, a prefix, a gateway and a list of DNS servers.
 func (m *IPPoolManager) allocateAddress(addressClaim *ipamv1.IPClaim,
 	addresses map[ipamv1.IPAddressStr]string,
 ) (ipamv1.IPAddressStr, int, *ipamv1.IPAddressStr, []ipamv1.IPAddressStr, error) {
@@ -320,6 +469,94 @@ func (m *IPPoolManager) allocateAddress(addressClaim *ipamv1.IPClaim,
 	return allocatedAddress, prefix, gateway, dnsServers, nil
 }
 
+// capiAllocateAddress gets an (capi)IpAddress for a (capi)IPAddressClaim.
+// it takes into consideration the possible preallocations.
+// Returns an IP address, a prefix and a gateway.
+func (m *IPPoolManager) capiAllocateAddress(addressClaim *capipamv1.IPAddressClaim,
+	addresses map[ipamv1.IPAddressStr]string,
+) (ipamv1.IPAddressStr, int, *ipamv1.IPAddressStr, error) {
+	var allocatedAddress ipamv1.IPAddressStr
+	var err error
+
+	// Get pre-allocated addresses
+	preAllocatedAddress, ipPreAllocated := m.IPPool.Spec.PreAllocations[addressClaim.Name]
+	// If the IP is pre-allocated, the default prefix and gateway are used
+	prefix := m.IPPool.Spec.Prefix
+	gateway := m.IPPool.Spec.Gateway
+
+	ipAllocated := false
+
+	for _, pool := range m.IPPool.Spec.Pools {
+		if ipAllocated {
+			break
+		}
+		index := 0
+		for !ipAllocated {
+			allocatedAddress, err = ipamv1.GetIPAddress(pool, index)
+			if err != nil {
+				break
+			}
+			index++
+			// We have a pre-allocated ip, we just need to ensure that it matches the current address
+			// if it does not, continue and try the next address
+			if ipPreAllocated && allocatedAddress != preAllocatedAddress {
+				continue
+			}
+			// Here the two addresses match, so we continue with that one
+			if ipPreAllocated {
+				ipAllocated = true
+			}
+			// If we have a preallocated address, this is useless, otherwise, check if the
+			// ip is free
+			if _, ok := addresses[allocatedAddress]; !ok && allocatedAddress != "" {
+				ipAllocated = true
+			}
+			if !ipAllocated {
+				continue
+			}
+
+			if pool.Prefix != 0 {
+				prefix = pool.Prefix
+			}
+			if pool.Gateway != nil {
+				gateway = pool.Gateway
+			}
+		}
+	}
+	// We have a preallocated IP but we did not find it in the pools! It means it is
+	// misconfigured
+	if !ipAllocated && ipPreAllocated {
+		conditions := clusterv1.Conditions{}
+		conditions = append(conditions, clusterv1.Condition{
+			Type:               "ErrorMessage",
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Severity:           "Error",
+			Reason:             "ErrorMessage",
+			Message:            "Pre-allocated IP out of bond",
+		})
+		addressClaim.SetConditions(conditions)
+		return "", 0, nil, errors.New("Pre-allocated IP out of bond")
+	}
+	if !ipAllocated {
+		conditions := clusterv1.Conditions{}
+		conditions = append(conditions, clusterv1.Condition{
+			Type:               "ErrorMessage",
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Severity:           "Error",
+			Reason:             "ErrorMessage",
+			Message:            "Exhausted IP Pools",
+		})
+		addressClaim.SetConditions(conditions)
+		return "", 0, nil, errors.New("Exhausted IP Pools")
+	}
+	return allocatedAddress, prefix, gateway, nil
+}
+
+// createAddress creates a (metal3)IPAddress object
+// Returns an updated map where IP addresses is key
+// and value is the associated (metal3 and/or capi) claim's name.
 func (m *IPPoolManager) createAddress(ctx context.Context,
 	addressClaim *ipamv1.IPClaim, addresses map[ipamv1.IPAddressStr]string,
 ) (map[ipamv1.IPAddressStr]string, error) {
@@ -418,6 +655,120 @@ func (m *IPPoolManager) createAddress(ctx context.Context,
 	return addresses, nil
 }
 
+// capiCreateAddress creates a (capi)IPAddress object
+// Returns an updated map where IP addresses is key
+// and value is the associated (metal3 and/or capi) claim's name.
+func (m *IPPoolManager) capiCreateAddress(ctx context.Context,
+	addressClaim *capipamv1.IPAddressClaim, addresses map[ipamv1.IPAddressStr]string,
+) (map[ipamv1.IPAddressStr]string, error) {
+	if !Contains(addressClaim.Finalizers, IPAddressClaimFinalizer) {
+		addressClaim.Finalizers = append(addressClaim.Finalizers,
+			IPAddressClaimFinalizer,
+		)
+	}
+
+	if allocatedAddress, ok := m.IPPool.Status.Allocations[addressClaim.Name]; ok {
+		addressClaim.Status.AddressRef = corev1.LocalObjectReference{
+			Name: m.formatAddressName(allocatedAddress),
+		}
+		return addresses, nil
+	}
+
+	// Get a new index for this machine
+	m.Log.Info("Getting address", "Claim", addressClaim.Name)
+	// Get a new IP for this owner
+	allocatedAddress, prefix, gateway, err := m.capiAllocateAddress(addressClaim, addresses)
+	if err != nil {
+		return addresses, err
+	}
+
+	var gatewayStr string
+	if gateway != nil {
+		gatewayStr = string(*gateway)
+	} else {
+		gatewayStr = ""
+	}
+
+	// Set the index and IPAddress names
+	addressName := m.formatAddressName(allocatedAddress)
+
+	m.Log.Info("Address allocated", "Claim", addressClaim.Name, "address", allocatedAddress)
+
+	ownerRefs := addressClaim.OwnerReferences
+	ownerRefs = append(ownerRefs,
+		metav1.OwnerReference{
+			APIVersion: m.IPPool.APIVersion,
+			Kind:       m.IPPool.Kind,
+			Name:       m.IPPool.Name,
+			UID:        m.IPPool.UID,
+		},
+		metav1.OwnerReference{
+			APIVersion: addressClaim.APIVersion,
+			Kind:       addressClaim.Kind,
+			Name:       addressClaim.Name,
+			UID:        addressClaim.UID,
+		},
+	)
+
+	// Create the IPAddress object, with an Owner ref to the IPAddressClaim,
+	// the IPPool, and the IPAddressClaim owners. Also add a finalizer.
+	addressObject := &capipamv1.IPAddress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "IPAddress",
+			APIVersion: capipamv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            addressName,
+			Namespace:       m.IPPool.Namespace,
+			Finalizers:      []string{IPAddressFinalizer},
+			OwnerReferences: ownerRefs,
+			Labels:          addressClaim.Labels,
+		},
+		Spec: capipamv1.IPAddressSpec{
+			Address: string(allocatedAddress),
+			PoolRef: corev1.TypedLocalObjectReference{
+				Name:     m.IPPool.Name,
+				Kind:     m.IPPool.Kind,
+				APIGroup: &APIGroup,
+			},
+			ClaimRef: corev1.LocalObjectReference{
+				Name: addressClaim.Name,
+			},
+			Prefix:  prefix,
+			Gateway: gatewayStr,
+		},
+	}
+
+	// Create the IPAddress object. If we get a conflict (that will set
+	// Transient error), then requeue to retrigger the reconciliation with
+	// the new state
+	if err := createObject(ctx, m.client, addressObject); err != nil {
+		var reconcileError ReconcileError
+		if !errors.As(err, &reconcileError) {
+			conditions := clusterv1.Conditions{}
+			conditions = append(conditions, clusterv1.Condition{
+				Type:               "ErrorMessage",
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Severity:           "Error",
+				Reason:             "ErrorMessage",
+				Message:            "Failed to create associated IPAddress object",
+			})
+			addressClaim.SetConditions(conditions)
+		}
+		return addresses, err
+	}
+
+	m.IPPool.Status.Allocations[addressClaim.Name] = allocatedAddress
+	addresses[allocatedAddress] = addressClaim.Name
+
+	addressClaim.Status.AddressRef = corev1.LocalObjectReference{
+		Name: addressName,
+	}
+
+	return addresses, nil
+}
+
 // deleteAddress removes the finalizer from the IPClaim and deletes the associated IPAddress.
 func (m *IPPoolManager) deleteAddress(ctx context.Context,
 	addressClaim *ipamv1.IPClaim, addresses map[ipamv1.IPAddressStr]string,
@@ -462,6 +813,82 @@ func (m *IPPoolManager) deleteAddress(ctx context.Context,
 	err := updateObject(ctx, m.client, addressClaim)
 	if err != nil && !apierrors.IsNotFound(err) {
 		m.Log.Info("Unable to remove finalizer from IPClaim", "IPClaim", addressClaim.Name)
+		return addresses, err
+	}
+
+	if ok {
+		if _, ok := m.IPPool.Spec.PreAllocations[addressClaim.Name]; !ok {
+			delete(addresses, allocatedAddress)
+		}
+		delete(m.IPPool.Status.Allocations, addressClaim.Name)
+		m.Log.Info("IPAddressClaim removed from IPPool allocations", "IPAddressClaim", addressClaim.Name)
+	}
+	m.updateStatusTimestamp()
+	return addresses, nil
+}
+
+// capideleteAddress removes the finalizer from the IPClaim and deletes the associated IPAddress.
+func (m *IPPoolManager) capiDeleteAddress(ctx context.Context,
+	addressClaim *capipamv1.IPAddressClaim, addresses map[ipamv1.IPAddressStr]string,
+) (map[ipamv1.IPAddressStr]string, error) {
+	m.Log.Info("Deleting IPAddress associated with IPAddressClaim", "IPAddressClaim", addressClaim.Name)
+
+	allocatedAddress, ok := m.IPPool.Status.Allocations[addressClaim.Name]
+	if ok {
+		// Try to get the IPAddress. if it succeeds, delete it
+		ipAddress := &capipamv1.IPAddress{}
+		key := client.ObjectKey{
+			Name:      m.formatAddressName(allocatedAddress),
+			Namespace: m.IPPool.Namespace,
+		}
+		err := m.client.Get(ctx, key, ipAddress)
+		if err != nil && !apierrors.IsNotFound(err) {
+			conditions := clusterv1.Conditions{}
+			conditions = append(conditions, clusterv1.Condition{
+				Type:               "ErrorMessage",
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+				Severity:           "Error",
+				Reason:             "ErrorMessage",
+				Message:            "Failed to get associated IPAddress object",
+			})
+			addressClaim.SetConditions(conditions)
+			return addresses, err
+		} else if err == nil {
+			// Remove the finalizer
+			ipAddress.Finalizers = Filter(ipAddress.Finalizers,
+				IPAddressFinalizer,
+			)
+			err = updateObject(ctx, m.client, ipAddress)
+			if err != nil && !apierrors.IsNotFound(err) {
+				m.Log.Info("Unable to remove finalizer from IPAddress", "IPAddress", ipAddress.Name)
+				return addresses, err
+			}
+			// Delete the IPAddress
+			err = deleteObject(ctx, m.client, ipAddress)
+			if err != nil {
+				conditions := clusterv1.Conditions{}
+				conditions = append(conditions, clusterv1.Condition{
+					Type:               "ErrorMessage",
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Now(),
+					Severity:           "Error",
+					Reason:             "ErrorMessage",
+					Message:            "Failed to delete associated IPAddress object",
+				})
+				addressClaim.SetConditions(conditions)
+				return addresses, err
+			}
+			m.Log.Info("Deleted IPAddress", "IPAddress", ipAddress.Name)
+		}
+	}
+	addressClaim.Status.AddressRef.Name = ""
+	addressClaim.Finalizers = Filter(addressClaim.Finalizers,
+		IPAddressClaimFinalizer,
+	)
+	err := updateObject(ctx, m.client, addressClaim)
+	if err != nil && !apierrors.IsNotFound(err) {
+		m.Log.Info("Unable to remove finalizer from IPAddressClaim", "IPAddressClaim", addressClaim.Name)
 		return addresses, err
 	}
 

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -39,6 +40,12 @@ var (
 		Namespace: "myns",
 	}
 	testObjectReference = &corev1.ObjectReference{
+		Name: "abc",
+	}
+	localtestObjectReference = &corev1.LocalObjectReference{
+		Name: "abc",
+	}
+	typedtestObjectReference = &corev1.TypedLocalObjectReference{
 		Name: "abc",
 	}
 )
@@ -150,6 +157,7 @@ var _ = Describe("IPPool manager", func() {
 	type testGetIndexes struct {
 		ipPool              *ipamv1.IPPool
 		addresses           []*ipamv1.IPAddress
+		capiAddresses       []*capipamv1.IPAddress
 		expectError         bool
 		expectedAddresses   map[ipamv1.IPAddressStr]string
 		expectedAllocations map[string]ipamv1.IPAddressStr
@@ -159,6 +167,9 @@ var _ = Describe("IPPool manager", func() {
 		func(tc testGetIndexes) {
 			objects := []client.Object{}
 			for _, address := range tc.addresses {
+				objects = append(objects, address)
+			}
+			for _, address := range tc.capiAddresses {
 				objects = append(objects, address)
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
@@ -263,7 +274,265 @@ var _ = Describe("IPPool manager", func() {
 				"abc": ipamv1.IPAddressStr("abcd1"),
 			},
 		}),
-		Entry("IPPool with deletion timestamp", testGetIndexes{
+		Entry("capi addresses", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta,
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"cbcd": "cbcde",
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc-0",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address:  "cabcd1",
+						PoolRef:  *typedtestObjectReference,
+						ClaimRef: *localtestObjectReference,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cbbc-1",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address: "cabcd2",
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cbbc",
+						},
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cbbc",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc-2",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address:  "cabcd3",
+						PoolRef:  corev1.TypedLocalObjectReference{},
+						ClaimRef: *localtestObjectReference,
+					},
+				},
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				"cabcd1": "abc",
+				"cbcde":  "",
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": "cabcd1",
+			},
+		}),
+		Entry("metal3 addresses and capi addresses", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta,
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"bcd":  "bcde",
+						"cbcd": "cbcde",
+					},
+				},
+			},
+			addresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-0",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd1",
+						Pool:    *testObjectReference,
+						Claim:   *testObjectReference,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bbc-1",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd2",
+						Pool: corev1.ObjectReference{
+							Name:      "bbc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "bbc",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-2",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd3",
+						Pool:    corev1.ObjectReference{},
+						Claim:   *testObjectReference,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-3",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd4",
+						Pool: corev1.ObjectReference{
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{},
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cbbc-1",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address: "cabcd2",
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cbbc",
+						},
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cbbc",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc-2",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address:  "cabcd3",
+						PoolRef:  corev1.TypedLocalObjectReference{},
+						ClaimRef: *localtestObjectReference,
+					},
+				},
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				"abcd1": "abc",
+				"bcde":  "",
+				"cbcde": "",
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": "abcd1",
+			},
+		}),
+		Entry("metal3 addresses and capi addresses 2", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: testObjectMeta,
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"bcd":  "bcde",
+						"cbcd": "cbcde",
+					},
+				},
+			},
+			addresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bbc-1",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd2",
+						Pool: corev1.ObjectReference{
+							Name:      "bbc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "bbc",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-2",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd3",
+						Pool:    corev1.ObjectReference{},
+						Claim:   *testObjectReference,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc-3",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Address: "abcd4",
+						Pool: corev1.ObjectReference{
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{},
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc-0",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address:  "cabcd1",
+						PoolRef:  *typedtestObjectReference,
+						ClaimRef: *localtestObjectReference,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cbbc-1",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address: "cabcd2",
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cbbc",
+						},
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cbbc",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc-2",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address:  "cabcd3",
+						PoolRef:  corev1.TypedLocalObjectReference{},
+						ClaimRef: *localtestObjectReference,
+					},
+				},
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				"bcde":   "",
+				"cabcd1": "abc",
+				"cbcde":  "",
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": "cabcd1",
+			},
+		}),
+		Entry("IPPool with deletion timestamp (metal3 addresses)", testGetIndexes{
 			ipPool: &ipamv1.IPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					DeletionTimestamp: &timeNow,
@@ -298,6 +567,91 @@ var _ = Describe("IPPool manager", func() {
 			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
 			expectedAllocations: map[string]ipamv1.IPAddressStr{},
 		}),
+		Entry("IPPool with deletion timestamp (capi addresses)", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &timeNow,
+				},
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"bcd": "bcde",
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-11",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "inUseClaim",
+						},
+						Address: "192.168.1.11",
+						Gateway: *ptr.To("192.168.0.1"),
+						Prefix:  24,
+					},
+				},
+			},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+		}),
+		Entry("IPPool with deletion timestamp (metal3 and capi addresses)", testGetIndexes{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &timeNow,
+				},
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"bcd": "bcde",
+					},
+				},
+			},
+			addresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-11",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "inUseClaim",
+							Namespace: "myns",
+						},
+						Address: "192.168.1.11",
+						Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+						Prefix:  24,
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabcpref-192-168-1-12",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cabc",
+						},
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "inUseClaim",
+						},
+						Address: "192.168.1.12",
+						Gateway: *(ptr.To("192.168.0.1")),
+						Prefix:  24,
+					},
+				},
+			},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+		}),
 	)
 
 	var ipPoolMeta = metav1.ObjectMeta{
@@ -309,6 +663,8 @@ var _ = Describe("IPPool manager", func() {
 		ipPool                *ipamv1.IPPool
 		ipClaims              []*ipamv1.IPClaim
 		ipAddresses           []*ipamv1.IPAddress
+		ipAddressClaims       []*capipamv1.IPAddressClaim
+		capiAddresses         []*capipamv1.IPAddress
 		expectRequeue         bool
 		expectError           bool
 		expectedNbAllocations int
@@ -322,6 +678,12 @@ var _ = Describe("IPPool manager", func() {
 				objects = append(objects, address)
 			}
 			for _, claim := range tc.ipClaims {
+				objects = append(objects, claim)
+			}
+			for _, address := range tc.capiAddresses {
+				objects = append(objects, address)
+			}
+			for _, claim := range tc.ipAddressClaims {
 				objects = append(objects, claim)
 			}
 			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithStatusSubresource(objects...).WithObjects(objects...).Build()
@@ -355,6 +717,18 @@ var _ = Describe("IPPool manager", func() {
 			for _, claim := range addressObjects.Items {
 				if claim.DeletionTimestamp.IsZero() {
 					Expect(claim.Status.Address).NotTo(BeNil())
+				}
+			}
+
+			// get list of IPAddress objects
+			capiAddressObjects := capipamv1.IPAddressClaimList{}
+			err = c.List(context.TODO(), &capiAddressObjects, opts)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Iterate over the IPAddress objects to find all indexes and objects
+			for _, claim := range capiAddressObjects.Items {
+				if claim.DeletionTimestamp.IsZero() {
+					Expect(claim.Status.AddressRef).NotTo(BeNil())
 				}
 			}
 
@@ -510,6 +884,382 @@ var _ = Describe("IPPool manager", func() {
 				"abce": ipamv1.IPAddressStr("192.168.1.12"),
 			},
 			expectedNbAllocations: 2,
+		}),
+		Entry("IPAddressClaim and IP exist", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					NamePrefix: "abcpref",
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *typedtestObjectReference,
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "abcpref-192-168-1-11",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcd",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "abcd",
+						},
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "abcpref-192-168-1-12",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abce",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *typedtestObjectReference,
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "abcpref-192-168-1-12",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "abcf",
+						Namespace:         "myns",
+						DeletionTimestamp: &timeNow,
+						Finalizers: []string{
+							IPAddressClaimFinalizer,
+						},
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *typedtestObjectReference,
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "abcpref-192-168-1-13",
+						},
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-11",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef:  *typedtestObjectReference,
+						ClaimRef: *localtestObjectReference,
+						Address:  "192.168.1.11",
+						Gateway:  *ptr.To("192.168.0.1"),
+						Prefix:   24,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-12",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "abce",
+						},
+						Address: "192.168.1.12",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-13",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "abcf",
+						},
+						Address: "192.168.1.13",
+					},
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc":  "192.168.1.11",
+				"abce": "192.168.1.12",
+			},
+			expectedNbAllocations: 2,
+		}),
+		Entry("Both IPClaim and IPAddressClaim and IP exist", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					NamePrefix: "abcpref",
+				},
+			},
+			ipClaims: []*ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-1-11",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcd",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abcd",
+							Namespace: "myns",
+						},
+					},
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-1-12",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abce",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-1-12",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "abcf",
+						Namespace:         "myns",
+						DeletionTimestamp: &timeNow,
+						Finalizers: []string{
+							ipamv1.IPClaimFinalizer,
+						},
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-1-13",
+							Namespace: "myns",
+						},
+					},
+				},
+			},
+			ipAddresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-11",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Address: "192.168.1.11",
+						Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+						Prefix:  24,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-12",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "abce",
+							Namespace: "myns",
+						},
+						Address: "192.168.1.12",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-1-13",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+						Claim: corev1.ObjectReference{
+							Name:      "abcf",
+							Namespace: "myns",
+						},
+						Address: "192.168.1.13",
+					},
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cabc",
+						},
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "cabcpref-192-168-1-14",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabcd",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cabcd",
+						},
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "cabcpref-192-168-1-15",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabce",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *typedtestObjectReference,
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "cabcpref-192-168-1-15",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "cabcf",
+						Namespace:         "myns",
+						DeletionTimestamp: &timeNow,
+						Finalizers: []string{
+							IPAddressClaimFinalizer,
+						},
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *typedtestObjectReference,
+					},
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: corev1.LocalObjectReference{
+							Name: "cabcpref-192-168-1-16",
+						},
+					},
+				},
+			},
+			capiAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabcpref-192-168-1-14",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: corev1.TypedLocalObjectReference{
+							Name: "cabc",
+						},
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cabc",
+						},
+						Address: "192.168.1.14",
+						Gateway: *(ptr.To("192.168.0.1")),
+						Prefix:  24,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabcpref-192-168-1-15",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cabce",
+						},
+						Address: "192.168.1.15",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabcpref-192-168-1-16",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "cabcf",
+						},
+						Address: "192.168.1.16",
+					},
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc":   "192.168.1.11",
+				"abce":  "192.168.1.12",
+				"cabce": "192.168.1.15",
+			},
+			expectedNbAllocations: 3,
 		}),
 		Entry("IPClaim with deletion timestamp and finalizers", testCaseUpdateAddresses{
 			ipPool: &ipamv1.IPPool{
@@ -775,6 +1525,218 @@ var _ = Describe("IPPool manager", func() {
 			expectedAllocations: map[string]ipamv1.IPAddressStr{},
 			expectedAddresses: map[ipamv1.IPAddressStr]string{
 				ipamv1.IPAddressStr("192.168.0.11"): "bcd",
+			},
+			expectedIPAddresses: []string{},
+			expectError:         true,
+		}),
+	)
+
+	type testCaseCapiCreateAddresses struct {
+		ipPool              *ipamv1.IPPool
+		ipAddressClaim      *capipamv1.IPAddressClaim
+		ipAddresses         []*capipamv1.IPAddress
+		addresses           map[ipamv1.IPAddressStr]string
+		expectRequeue       bool
+		expectError         bool
+		expectedIPAddresses []string
+		expectedAddresses   map[ipamv1.IPAddressStr]string
+		expectedAllocations map[string]ipamv1.IPAddressStr
+	}
+
+	DescribeTable("Test capiCreateAddresses",
+		func(tc testCaseCapiCreateAddresses) {
+			objects := []client.Object{}
+			for _, address := range tc.ipAddresses {
+				objects = append(objects, address)
+			}
+			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			ipPoolMgr, err := NewIPPoolManager(c, tc.ipPool,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedMap, err := ipPoolMgr.capiCreateAddress(context.TODO(), tc.ipAddressClaim,
+				tc.addresses,
+			)
+			if tc.expectRequeue || tc.expectError {
+				Expect(err).To(HaveOccurred())
+				if tc.expectRequeue {
+					Expect(err).To(BeAssignableToTypeOf(ReconcileError{}))
+				} else {
+					Expect(err).NotTo(BeAssignableToTypeOf(ReconcileError{}))
+				}
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			// get list of IPAddress objects
+			addressObjects := capipamv1.IPAddressList{}
+			opts := &client.ListOptions{}
+			err = c.List(context.TODO(), &addressObjects, opts)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(tc.expectedIPAddresses)).To(Equal(len(addressObjects.Items)))
+			// Iterate over the IPAddress objects to find all indexes and objects
+			for _, address := range addressObjects.Items {
+				Expect(tc.expectedIPAddresses).To(ContainElement(address.Name))
+				// TODO add further testing later
+			}
+
+			Expect(allocatedMap).To(Equal(tc.expectedAddresses))
+			Expect(tc.ipPool.Status.Allocations).To(Equal(tc.expectedAllocations))
+		},
+		Entry("Already exists", testCaseCapiCreateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{
+						"abc": "foo-0",
+					},
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": "foo-0",
+			},
+		}),
+		Entry("Not allocated yet, pre-allocated", testCaseCapiCreateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"abc": "192.168.0.15",
+					},
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": ipamv1.IPAddressStr("192.168.0.15"),
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.15"): "abc",
+			},
+			expectedIPAddresses: []string{"abcpref-192-168-0-15"},
+		}),
+		Entry("Not allocated yet", testCaseCapiCreateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.11": "bcd",
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{
+				"abc": "192.168.0.12",
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.12": "abc",
+				"192.168.0.11": "bcd",
+			},
+			expectedIPAddresses: []string{"abcpref-192-168-0-12"},
+		}),
+		Entry("Not allocated yet, conflict", testCaseCapiCreateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			ipAddresses: []*capipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abcpref-192-168-0-11",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressSpec{
+						Address: "192.168.0.11",
+						PoolRef: *typedtestObjectReference,
+						ClaimRef: corev1.LocalObjectReference{
+							Name: "bcd",
+						},
+					},
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+			expectedIPAddresses: []string{"abcpref-192-168-0-11"},
+			expectRequeue:       true,
+		}),
+		Entry("Not allocated yet, exhausted pool", testCaseCapiCreateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+						},
+					},
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.11": "bcd",
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.11": "bcd",
 			},
 			expectedIPAddresses: []string{},
 			expectError:         true,
@@ -1121,6 +2083,293 @@ var _ = Describe("IPPool manager", func() {
 		}),
 	)
 
+	type testCapiCaseAllocateAddress struct {
+		ipPool          *ipamv1.IPPool
+		addresses       map[ipamv1.IPAddressStr]string
+		ipAddressClaim  *capipamv1.IPAddressClaim
+		expectedAddress ipamv1.IPAddressStr
+		expectedPrefix  int
+		expectedGateway *ipamv1.IPAddressStr
+		expectError     bool
+	}
+
+	DescribeTable("Test capiAllocateAddress",
+		func(tc testCapiCaseAllocateAddress) {
+			ipPoolMgr, err := NewIPPoolManager(nil, tc.ipPool,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			allocatedAddress, prefix, gateway, err := ipPoolMgr.capiAllocateAddress(
+				tc.ipAddressClaim, tc.addresses,
+			)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocatedAddress).To(Equal(tc.expectedAddress))
+			Expect(prefix).To(Equal(tc.expectedPrefix))
+			Expect(*gateway).To(Equal(*tc.expectedGateway))
+		},
+		Entry("Empty pools", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "abc",
+				},
+			},
+			expectError: true,
+		}),
+		Entry("One pool, pre-allocated", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:     (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+							Prefix:  26,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+						},
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.21")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.30")),
+						},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.21"),
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.21"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("One pool, pre-allocated, with overrides", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:     (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+							Prefix:  26,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+						},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.15"),
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.15"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+			expectedPrefix:  26,
+		}),
+		Entry("One pool, pre-allocated, out of bonds", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:     (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+							Prefix:  26,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+						},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.21"),
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			expectError: true,
+		}),
+		Entry("One pool, with start and existing address", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.13"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("One pool, with subnet and override prefix", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:     (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+							Prefix:  24,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+						},
+					},
+					Prefix:  26,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.13"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("two pools, with subnet and override prefix in first", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:     (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							Prefix:  24,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+						},
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.1.10/24")),
+						},
+					},
+					Prefix:  26,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.2.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.1.11"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.10"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.1.12"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.2.1")),
+			expectedPrefix:  26,
+		}),
+		Entry("two pools, with subnet and override prefix", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+						},
+						{
+							Subnet:  (*ipamv1.IPSubnetStr)(ptr.To("192.168.1.10/24")),
+							Prefix:  24,
+							Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+						},
+					},
+					Prefix:  26,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.2.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.1.11"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.10"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.1.12"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("Exhausted pools start", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.10"): "abcd",
+			},
+			expectError: true,
+		}),
+		Entry("Exhausted pools subnet", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Subnet: (*ipamv1.IPSubnetStr)(ptr.To("192.168.0.0/30")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.1"): "abcd",
+				ipamv1.IPAddressStr("192.168.0.2"): "abcd",
+				ipamv1.IPAddressStr("192.168.0.3"): "abcd",
+			},
+			expectError: true,
+		}),
+	)
+
 	type testCaseDeleteAddresses struct {
 		ipPool              *ipamv1.IPPool
 		ipClaim             *ipamv1.IPClaim
@@ -1227,6 +2476,121 @@ var _ = Describe("IPPool manager", func() {
 			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
 			expectedAllocations: map[string]ipamv1.IPAddressStr{},
 			m3addresses: []*ipamv1.IPAddress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "abc-192-168-0-1",
+					},
+				},
+			},
+		}),
+	)
+
+	type testCaseCapiDeleteAddresses struct {
+		ipPool              *ipamv1.IPPool
+		ipAddressClaim      *capipamv1.IPAddressClaim
+		capiAddresses       []*capipamv1.IPAddress
+		addresses           map[ipamv1.IPAddressStr]string
+		expectedAddresses   map[ipamv1.IPAddressStr]string
+		expectedAllocations map[string]ipamv1.IPAddressStr
+		expectError         bool
+	}
+
+	DescribeTable("Test capiDeleteAddresses",
+		func(tc testCaseCapiDeleteAddresses) {
+			objects := []client.Object{}
+			for _, address := range tc.capiAddresses {
+				objects = append(objects, address)
+			}
+			c := fakeclient.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+			ipPoolMgr, err := NewIPPoolManager(c, tc.ipPool,
+				logr.Discard(),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedMap, err := ipPoolMgr.capiDeleteAddress(context.TODO(), tc.ipAddressClaim, tc.addresses)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// get list of IPAddress objects
+			addressObjects := capipamv1.IPAddressList{}
+			opts := &client.ListOptions{}
+			err = c.List(context.TODO(), &addressObjects, opts)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(addressObjects.Items)).To(Equal(0))
+
+			Expect(tc.ipPool.Status.LastUpdated.IsZero()).To(BeFalse())
+			Expect(allocatedMap).To(Equal(tc.expectedAddresses))
+			Expect(tc.ipPool.Status.Allocations).To(Equal(tc.expectedAllocations))
+			Expect(len(tc.ipAddressClaim.Finalizers)).To(Equal(0))
+		},
+		Entry("Empty IPPool", testCaseCapiDeleteAddresses{
+			ipPool: &ipamv1.IPPool{},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+		}),
+		Entry("No Deletion needed", testCaseCapiDeleteAddresses{
+			ipPool: &ipamv1.IPPool{},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			expectedAddresses: map[ipamv1.IPAddressStr]string{"192.168.0.1": "abcd"},
+			addresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.1": "abcd",
+			},
+		}),
+		Entry("Deletion needed, not found", testCaseCapiDeleteAddresses{
+			ipPool: &ipamv1.IPPool{
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": "192.168.0.1",
+					},
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.1": "TestRef",
+			},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+		}),
+		Entry("Deletion needed", testCaseCapiDeleteAddresses{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					NamePrefix: "abc",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": "192.168.0.1",
+					},
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Finalizers: []string{
+						IPAddressClaimFinalizer,
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				"192.168.0.1": "TestRef",
+			},
+			expectedAddresses:   map[ipamv1.IPAddressStr]string{},
+			expectedAllocations: map[string]ipamv1.IPAddressStr{},
+			capiAddresses: []*capipamv1.IPAddress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "abc-192-168-0-1",

--- a/ipam/suite_test.go
+++ b/ipam/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -71,6 +72,9 @@ var _ = BeforeSuite(func() {
 		err = ipamv1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
+		err = capipamv1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
 		err = apiextensionsv1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -101,6 +105,9 @@ var _ = AfterSuite(func() {
 func setupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	if err := ipamv1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	if err := capipamv1.AddToScheme(s); err != nil {
 		panic(err)
 	}
 	return s

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,33 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+- major: 1
+  minor: 10
+  contract: v1beta1
+- major: 1
+  minor: 9
+  contract: v1beta1
+- major: 1
+  minor: 8
+  contract: v1beta1
+- major: 1
+  minor: 7
+  contract: v1beta1
+- major: 1
+  minor: 6
+  contract: v1beta1
+- major: 1
+  minor: 5
+  contract: v1beta1
+- major: 1
+  minor: 4
+  contract: v1beta1
+- major: 1
+  minor: 3
+  contract: v1beta1
+- major: 1
+  minor: 2
+  contract: v1beta1
+- major: 1
+  minor: 1
+  contract: v1beta1


### PR DESCRIPTION
This commit makes it possible to:
- Deploy IPAM with clusterctl
- Reconsile CAPI's ipaddressclaims with this managers ippools

I have two PR's, one in metal-dev-env and one in CAPM3 to mach these changes 
- metal3-de-env: https://github.com/metal3-io/metal3-dev-env/pull/1459
- CAPM3: https://github.com/metal3-io/cluster-api-provider-metal3/pull/1993

All three PRs' changes need to be tested together. Check test in the metal-dev-env PR.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: To make this IPAM into a provider for CAPI 