### PR TITLE
:seedling: add osv-scanner config for correcting go version used

### DIFF
--- a/.github/workflows/osv-scanner-scan.yml
+++ b/.github/workflows/osv-scanner-scan.yml
@@ -1,46 +1,49 @@
-# This file is adapted from https://github.com/google/osv-scanner
-
+# runs vulnerability scans and add them to Github Security tab
 
 name: OSV-Scanner Scan
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "12 6 * * 1"
 
-# Restrict jobs in this workflow to have no permissions by default; permissions
-# should be granted per job as needed using a dedicated `permissions` block
 permissions: {}
 
 jobs:
   scan-scheduled:
     permissions:
       actions: read
-      contents: read # to fetch code (actions/checkout)
+      contents: read
       security-events: write # for uploading SARIF files
     if: ${{ github.repository == 'metal3-io/ip-address-manager' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Calculate go version
-        id: vars
-        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
-      - name: Set up Go
-        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-        with:
-          go-version: ${{ steps.vars.outputs.go_version }}
-      - name: Install OSV Scanner
-        run: go install github.com/google/osv-scanner/cmd/osv-scanner@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1
-      - name: Run OSV Scanner
-        run: osv-scanner scan --format json --output results.json --recursive --skip-git ./
-        continue-on-error: true
-      - name: "Run OSV Scanner Reporter"
-        uses: google/osv-scanner/actions/reporter@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1
-        with:
-           scan-args: |-
-            --output=results.sarif
-            --new=results.json
-            --gh-annotations=false
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: results.sarif
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> "${GITHUB_OUTPUT}"
+    - name: Set up Go
+      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - name: Install OSV Scanner
+      run: go install github.com/google/osv-scanner/cmd/osv-scanner@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1
+    - name: Run OSV Scanner
+      run: |
+        osv-scanner scan \
+          --format json --output results.json --recursive --skip-git \
+          --config=<( echo "GoVersionOverride = \"${{ steps.vars.outputs.go_version }}\"" ) \
+          ./
+      continue-on-error: true
+    - name: "Run OSV Scanner Reporter"
+      uses: google/osv-scanner/actions/reporter@b13f37e1a1e4cb98556c1d34cd3256a876929be1 # v1.9.1
+      with:
+        scan-args: |-
+          --output=results.sarif
+          --new=results.json
+          --gh-annotations=false
+      continue-on-error: true
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@396bb3e45325a47dd9ef434068033c6d5bb0d11a # v3.27.3
+      with:
+        sarif_file: results.sarif


### PR DESCRIPTION
Use OSV scanner config, that sets the used go version manually, instead of osv-scanner detecting it from go.mod, which is not correct way for us. Go version from go.mod is not user-friendly way of bumping Go as it forced everyone downstream to use that Go version or newer, forcing unwanted toolchain bumps.

It also changes the reporter action to not fail if there are vulns, we want to get the vulns into Security tab, and failing a scan should mean the scan action itself had issue.

TODO items for later PRs:
- release branch support (scheduled actions cannot target other branches directly)
