### PR TITLE
:bug: Fix ignored errors while patching resources

### DIFF
--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -82,6 +82,7 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		err := helper.Patch(ctx, ipamv1IPPool)
 		if err != nil {
 			metadataLog.Info("failed to Patch ipamv1IPPool")
+			rerr = err
 		}
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Errors during deferred actions were not reported in the result of the main reconcilers. It may mean that the resource will never
get patched if no other reconcile event is triggered.

Same pattern as https://github.com/metal3-io/cluster-api-provider-metal3/pull/2003

**Alternative implementation**
To avoid the check on delete, it is possible to remove [updateObject](https://github.com/metal3-io/ip-address-manager/blob/176d4d0fc738fc3d46a06f2593b982e96a082964/ipam/ippool_manager.go#L457) in deleteAddress. But then if the patch fails (should be a transient error), the IPPool spec and status have already been modified which can have unintended effects.
