### PR TITLE
:seedling: bump markdownlint-cli2 to v0.12.0 

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -29,7 +29,7 @@ but essentially, for any given release X.Y.Z:
 - a Z (**patch**) release indicates minimum set of bugfixes.  Changing
   Z means a backwards-compatible change that doesn't add functionality.
 
-*NB*: If the major release is `0`, any minor release may contain breaking
+_NB_: If the major release is `0`, any minor release may contain breaking
 changes.
 
 These guarantees extend to all code exposed in public APIs of
@@ -166,7 +166,7 @@ Furthermore, our dependency on Kubernetes libraries makes this difficult
 
 ### Always assume we've broken compatibility
 
-*a.k.a. k8s.io/client-go style* While this makes life easier (a bit) for
+_a.k.a. k8s.io/client-go style_ While this makes life easier (a bit) for
 maintainers, it's problematic for users.  While breaking changes arrive sooner,
 upgrading becomes very painful.
 

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -15,6 +15,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0 \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
With fixes to formatting.

Manual cherry-pick of #699 