### PR TITLE
🌱 Enable TLS 1.3 flag in IPAM

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         - "--webhook-port=9443"
         - "--diagnostics-address=${IPAM_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${IPAM_INSECURE_DIAGNOSTICS:=false}"
+        - "--tls-min-version=${TLS_MIN_VERSION:=VersionTLS13}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
PR will add the` --tls-min-version` flag value to `VersionTLS13` to use TLS 1.3.