### PR TITLE
🌱 Increase time for golint test to avoid timeout failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ $(KUSTOMIZE): $(TOOLS_DIR)/go.mod
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=5m
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 
 .PHONY: lint-fix


### PR DESCRIPTION
We have seen failure in golint test failure because of time out. Sometimes it takes more than 5 minutes to finish the job. So increasing the test timeout should fix this failure.
