### PR TITLE
:seedling: bump Go to 1.23.3 and golangci-lint to 1.60.3

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [ opened, edited, synchronize, reopened ]
 
 permissions: {}
 
@@ -30,5 +30,6 @@ jobs:
     - name: golangci-lint-${{matrix.working-directory}}
       uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
       with:
-        version: v1.56.2
+        version: v1.60.3
         working-directory: ${{matrix.working-directory}}
+        args: --timeout=15m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,15 @@
 run:
-  deadline: 5m
-  skip-dirs:
-  - mock*
-  skip-files:
-  - "zz_generated.*\\.go$"
-  - ".*conversion.*\\.go$"
+  go: "1.23"
+  deadline: 10m
 linters:
   disable-all: true
   enable:
   - asciicheck
   - bodyclose
+  - copyloopvar
   - dogsled
   - errcheck
   - errorlint
-  - exportloopref
   - goconst
   - gocritic
   - godot
@@ -45,7 +41,7 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.22"
+    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -75,10 +71,6 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
-  staticcheck:
-    go: "1.22"
-  stylecheck:
-    go: "1.22"
   gocritic:
     enabled-tags:
     - experimental
@@ -97,8 +89,13 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.22"
+    go: "1.23"
 issues:
+  skip-dirs:
+  - mock*
+  skip-files:
+  - "zz_generated.*\\.go$"
+  - ".*conversion.*\\.go$"
   exclude-rules:
   - path: _test\.go
     linters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.22.9@sha256:97ccb917d1dfe5b12cb4cfea1fb37989b28d3a87d28e89f27a71336c4700a87f
+ARG BUILD_IMAGE=docker.io/golang:1.23.3@sha256:d56c3e08fe5b27729ee3834854ae8f7015af48fd651cd25d1e3bcf3c19830174
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.22.9
+GO_VERSION ?= 1.23.3
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,10 +60,10 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="1.56.2"
+    GOLANGCI_VERSION="1.60.3"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="5f9ecda712c7ae08fbf872336fae3db866720e5865903d4c53903184b2a2c2dc" ;;
-        linux-amd64) GOLANGCI_SHA256="e1c313fb5fc85a33890fdee5dbb1777d1f5829c84d655a47a55688f3aad5e501" ;;
+        darwin-arm64) GOLANGCI_SHA256="deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f" ;;
+        linux-amd64) GOLANGCI_SHA256="4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef" ;;
       *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -189,7 +189,6 @@ func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
 
 	// Iterate over the IPClaim objects to find all addresses and objects
 	for _, addressClaim := range addressClaimObjects.Items {
-		addressClaim := addressClaim
 		// If IPPool does not point to this object, discard
 		if addressClaim.Spec.Pool.Name != m.IPPool.Name {
 			continue


### PR DESCRIPTION
Bump Go to 1.23.3 and golangci-lint to 1.60.3, which supports Go 1.23.

Update golangci-lint config, remove deprecations there.

Fix new issues found by golangci-lint.

Fixes: #716 