### PR TITLE
🌱 Fixing release note generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,6 @@ release:
 	git checkout "${RELEASE_TAG}"
 	MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image
 	$(MAKE) release-manifests
-	$(MAKE) release-notes
 
 ## --------------------------------------
 ## Cleanup / Verification


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

- Fixing release note generation logic for beta, rc and minor releases
- Fix markdownlint issues in release note generation.
- Removing `$(MAKE) release-notes` form `make release`, this is not needed, release notes will be fetched from the merged release notes PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
