### PR TITLE
:seedling: Lint hack/tools

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,6 +17,10 @@ jobs:
         working-directory:
         - ""
         - api
+        - hack/tools/release
+        include:
+        - working-directory: hack/tools/release
+          additional-args: --build-tags=tools --modules-download-mode=readonly
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,4 +36,4 @@ jobs:
       with:
         version: v1.60.3
         working-directory: ${{matrix.working-directory}}
-        args: --timeout=15m
+        args: --timeout=15m ${{matrix.additional-args}}

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ $(KUSTOMIZE): $(TOOLS_DIR)/go.mod
 lint: $(GOLANGCI_LINT) ## Lint codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
@@ -150,6 +151,7 @@ lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast=false
 	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v --fast=false --timeout=30m
+	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --fast=false --build-tags=tools --modules-download-mode=readonly --timeout=30m
 
 ## --------------------------------------
 ## Generate


### PR DESCRIPTION
**What this PR does / why we need it**:

Added the hack/tools/release directory to be linted like the rest of the repo. Attempted to do the hack/tools directory but ran into typecheck errors stating that the imports were not packages. Per golangci-lint's docs, [you can't skip or ignore these errors](https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors). Instead of modifying the import, I opted for just scanning the actual code.

Something to note, some of the keys within the [.golangci.yml](https://github.com/metal3-io/ip-address-manager/blob/main/.golangci.yaml) at not valid such as the [issues.skip-dirs](https://github.com/metal3-io/ip-address-manager/blob/main/.golangci.yaml#L94) and issues.skip-files. When playing around with the configuration they were a gotcha that got me.

Addressed issues identified by the linters.

**Tested via**:

local: within hack/tools/release dir `golangci-lint run --build-tags=tools --modules-download-mode=readonly`
act: repo root `act -j golangci`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #767 
