### PR TITLE
:bug: Fix release-notes in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ release-manifests: $(KUSTOMIZE) $(RELEASE_DIR) ## Builds the manifests to publis
 
 .PHONY: release-notes-tool
 release-notes-tool:
-	go build -C hack/tools -o $(BIN_DIR) -tags tools github.com/metal3-io/ip-address-manager/hack/tools/release
+	go build -C hack/tools -o $(BIN_DIR)/release -tags tools github.com/metal3-io/ip-address-manager/hack/tools/release
 
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES) release-notes-tool

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,12 +32,15 @@ IPAM uses [semantic versioning](https://semver.org).
 
 ### Repository setup
 
-Clone the repository from your intended fork:
+- Clone the repository from your intended fork:
 `git clone git@github.com:[your-fork]/metal3-ipam.git`
 
 or if using existing repository, make sure origin is set to the fork and
 upstream is set to `metal3-io`. Verify if your remote is set properly or not
 by using following command `git remote -v`.
+
+- Fetch the remote (`metal3-io`): `git fetch upstream`
+This makes sure that all the tags are accessible.
 
 ### Creating Release Notes
 
@@ -61,9 +64,11 @@ by using following command `git remote -v`.
      release, but not overwhelming the important changes contained by the
      release.
 
-- Commit and push your changes, push the new branch and create a pull request.
+- Commit your changes, push the new branch and create a pull request:
 IMPORTANT_NOTE:
-   - The commit and PR title should be 🚀 Release v1.x.y.
+   - The commit and PR title should be 🚀 Release v1.x.y:
+      -`git commit -S -s -m ":rocket: Release v1.x.x"`
+      -`git push -u origin release-notes-1.x.x`
    - Important! The commit should only contain the release notes file, nothing
      else, otherwise automation will not work.
 

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -125,16 +125,16 @@ func isMinor(tag string) bool {
 func run() int {
 	latestTag, err := latestTag()
 	if err != nil {
-		log.Fatal("Failed to get latestTag \n")
+		log.Fatalf("Failed to get latestTag: %v", err)
 	}
 	lastTag, err := lastTag(latestTag)
 	if err != nil {
-		log.Fatal("Failed to get lastTag \n")
+		log.Fatalf("Failed to get lastTag: %v", err)
 	}
 
 	commitHash, err := getCommitHashFromNewTag(latestTag)
 	if err != nil {
-		log.Fatalf("Failed to get commit has from latestTag %s", latestTag)
+		log.Fatalf("Failed to get commit hash from latestTag %s: %v", latestTag, err)
 	}
 
 	cmd := exec.Command("git", "rev-list", lastTag+".."+commitHash, "--merges", "--pretty=format:%B") // #nosec G204:gosec


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Fix the path release binary is created in. Add more logging and documentation to reduce user error when using release-notes action from Makefile. 

