### PR TITLE
:seedling: replace release-1.7 with 1.9 in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,25 +26,68 @@ updates:
   target-branch: main
   groups:
     kubernetes:
-      patterns: ["k8s.io/*"]
+      patterns: [ "k8s.io/*" ]
     capi:
-      patterns: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"]
+      patterns: [ "sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test" ]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-tools"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
 ## main branch config ends here
+## release-1.9 branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+    day: "monday"
+  target-branch: release-1.9
+  ignore:
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/api"
+  - "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  target-branch: release-1.9
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+    capi:
+      patterns: [ "sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test" ]
+  ignore:
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: [ "version-update:semver-major" ]
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+## release-1.9 branch config ends here
+
 ## release-1.8 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
@@ -55,7 +98,7 @@ updates:
   ignore:
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   commit-message:
     prefix: ":seedling:"
   labels:
@@ -72,60 +115,18 @@ updates:
   target-branch: release-1.8
   groups:
     kubernetes:
-      patterns: ["k8s.io/*"]
+      patterns: [ "k8s.io/*" ]
     capi:
-      patterns: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"]
+      patterns: [ "sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test" ]
   ignore:
   # golang.org/x/* only releases minors no patches, so minors have to be allowed
   - dependency-name: "golang.org/x/*"
-    update-types: ["version-update:semver-major"]
+    update-types: [ "version-update:semver-major" ]
   # Ignore major and minor bumps for release branch
   - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
 ## release-1.8 branch config ends here
-## release-1.7 branch config starts here
-- package-ecosystem: "github-actions"
-  directory: "/" # Location of package manifests
-  schedule:
-    interval: "monthly"
-    day: "monday"
-  target-branch: release-1.7
-  ignore:
-  # Ignore major and minor bumps for release branch
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-  - "ok-to-test"
-  # Go
-- package-ecosystem: "gomod"
-  directories:
-  - "/"
-  - "/api"
-  - "/hack/tools"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  target-branch: release-1.7
-  groups:
-    kubernetes:
-      patterns: ["k8s.io/*"]
-    capi:
-      patterns: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"]
-  ignore:
-  # golang.org/x/* only releases minors no patches, so minors have to be allowed
-  - dependency-name: "golang.org/x/*"
-    update-types: ["version-update:semver-major"]
-  # Ignore major and minor bumps for release branch
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-  - "ok-to-test"
-## release-1.7 branch config ends here


### PR DESCRIPTION
Replace release-1.7 with release-1.9 branch in dependabot config. 1.7 moves to tested only status, and 1.8 and 1.9 are maintained along with main.
