### PR TITLE
:seedling: Add build container image as a job in release wf

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -10,11 +10,6 @@ on:
     - "release-*"
     tags:
     - "v*"
-  workflow_run:
-    workflows:
-    - "Create Release"
-    types:
-    - completed
 
 jobs:
   set_ref:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,3 +116,17 @@ jobs:
         files: out/*
         body_path: ${{ env.RELEASE_TAG }}.md
         tag_name: ${{ env.RELEASE_TAG }}
+
+  build_ipam:
+    needs: push_release_tags
+    name: Build IPAM container image
+    if: github.repository == 'metal3-io/ip-address-manager'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: "ip-address-manager"
+      pushImage: true
+      ref: ${{ needs.push_release_tags.outputs.release_tag }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This adds build-container-image as a job in the release wf. After the release note draft is created, the container image will be created.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #772 
