### PR TITLE
:seedling: Add read permission to build job in release wf

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,6 +118,8 @@ jobs:
         tag_name: ${{ env.RELEASE_TAG }}
 
   build_ipam:
+    permissions:
+      contents: read
     needs: push_release_tags
     name: Build IPAM container image
     if: github.repository == 'metal3-io/ip-address-manager'


### PR DESCRIPTION
Build job requires read permission to run.