### PR TITLE
:seedling: bump kubeconform to v0.6.7

### DIFF
--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -35,6 +35,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        ghcr.io/yannh/kubeconform:v0.6.2-alpine@sha256:49b5f6b320d30c1b8b72a7abdf02740ac9dc36a3ba23b934d1c02f7b37e6e740 \
+        ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6 \
         "${WORKDIR}"/hack/manifestlint.sh "$@"
 fi


### PR DESCRIPTION
Bump manifestlint's kubeconform image to v0.6.7.

There are no failures in target repos due to bump, will not backport the bump to release branches.