### PR TITLE
:bug: bump golang to 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.23.4@sha256:574185e5c6b9d09873f455a7c205ea0514bfd99738c5dc7750196403a44ed4b7
+ARG BUILD_IMAGE=docker.io/golang:1.23.5@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.23.4
+GO_VERSION ?= 1.23.5
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)


### PR DESCRIPTION
Golang stdlib has issue in crypto/x509, fixed in golang 1.23.5. https://osv.dev/GO-2025-3373

Golang stdlib has issue in net/http, fixed in golang 1.23.5. https://osv.dev/vulnerability/GO-2025-3420

Both codepaths are used in the code.
