### PR TITLE
:seedling: pin osv-scanner image in verify-release.sh

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -145,7 +145,7 @@ if [[ -n "${CONTAINER_RUNTIME}" ]]; then
         "${CONTAINER_RUNTIME}" run --rm
         -v "${PWD}":/src -w /src
         --pull always
-        ghcr.io/google/osv-scanner:latest
+        ghcr.io/google/osv-scanner:v1.9.2@sha256:239d47ec1a70af430c3cd57524d18e8b2d2dc2f28869384217b64f409ab6650a
     )
 else
     # go install github.com/google/go-containerregistry/cmd/gcrane@latest


### PR DESCRIPTION
osv-scanner:latest image is built from unpublished v2 branch now, which does not support same command line args as v1. Pin it to v1.9.2 for now and bump the command line usage to v2 compatible when it is published.
