### PR TITLE
:seedling: fix dependabot testing issues by re-adding "edited"

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}
 

--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -2,7 +2,7 @@ name: Check Markdown links
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
     paths:
     - '**.md'
 

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -6,7 +6,6 @@ name: Approve GH Workflows
 
 on:
   pull_request_target:
-    # edited is needed here as this workflow checks for PR meta content
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions: {}

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -4,7 +4,6 @@ permissions: {}
 
 on:
   pull_request_target:
-    # edited is needed here as this workflow checks for PR meta content
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:


### PR DESCRIPTION
Re-adding "edited" trigger to testing workflows to workaround Dependabot workflow issue.

Ref: https://github.com/metal3-io/ironic-standalone-operator/issues/162 