### PR TITLE
:seedling: bump tj-actions/changed-files to v46.0.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # tag=v45.0.7
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
     - name: Get release version
       id: release-version
       run: |


### PR DESCRIPTION
Since the exploit code was added and then removed to this action, it looks like they moved all the v45 tags to point to same updated commit. This makes Dependabot confused. Let's bump it to latest release v46.0.1.
