### PR TITLE
🌱  Bump golangci-lint to v1.64.7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,8 +32,8 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
-      uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
       with:
-        version: v1.60.3
+        version: v1.64.7
         working-directory: ${{matrix.working-directory}}
-        args: --timeout=15m ${{matrix.additional-args}}
+        args: --timeout=10m ${{matrix.additional-args}}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,5 @@
 run:
   go: "1.23"
-  deadline: 10m
 linters:
   disable-all: true
   enable:
@@ -41,7 +40,6 @@ linters:
 
 linters-settings:
   gosec:
-    go: "1.23"
     severity: medium
     confidence: medium
     concurrency: 8
@@ -69,7 +67,6 @@ linters-settings:
       alias: ipamv1
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
   gocritic:
     enabled-tags:
@@ -88,12 +85,10 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
-  unused:
-    go: "1.23"
 issues:
-  skip-dirs:
+  exclude-dirs:
   - mock*
-  skip-files:
+  exclude-files:
   - "zz_generated.*\\.go$"
   - ".*conversion.*\\.go$"
   exclude-rules:

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,10 +60,10 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="1.60.3"
+    GOLANGCI_VERSION="1.64.7"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="deb0fbd0b99992d97808614db1214f57d5bdc12b907581e2ef10d3a392aca11f" ;;
-        linux-amd64) GOLANGCI_SHA256="4037af8122871f401ed874852a471e54f147ff8ce80f5a304e020503bdb806ef" ;;
+        darwin-arm64) GOLANGCI_SHA256="9ff4b40bd4c8cd199d010c0e96e424416c32827fce0fb7eedebb48294106623b" ;;
+        linux-amd64) GOLANGCI_SHA256="dada4095eab53f868f931840f04b99cb4be654e45f50d4d3b2832dc9ad3bede8" ;;
       *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1


### PR DESCRIPTION
This PR also bumps golangci-lint-action to 6.5.2. While doing that it removes some of the old unsupported golangci-lint settings.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>

