### PR TITLE
🌱 Enable errname, forbidigo, forcetypeassert, mnd, perfsprint and unparam linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,13 +16,13 @@ linters:
   - durationcheck
   - errcheck
   - errchkjson
-  #- errname
+  - errname
   - errorlint
   - exhaustive
   - exptostd
   - fatcontext
-  #- forbidigo
-  #- forcetypeassert
+  - forbidigo
+  - forcetypeassert
   #- gci
   - ginkgolinter
   - gocheckcompilerdirectives
@@ -45,7 +45,7 @@ linters:
   - makezero
   - mirror
   - misspell
-  #- mnd
+  - mnd
   - nakedret
   - nilerr
   - nilnesserr
@@ -53,7 +53,7 @@ linters:
   - noctx
   - nolintlint
   - nosprintfhostport
-  #- perfsprint
+  - perfsprint
   - prealloc
   - predeclared
   - reassign
@@ -67,7 +67,7 @@ linters:
   - tparallel
   - typecheck
   - unconvert
-  #- unparam
+  - unparam
   - unused
   - usestdlibvars
   - usetesting

--- a/api/v1alpha1/utils_test.go
+++ b/api/v1alpha1/utils_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/utils/ptr"
 )
 

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -20,13 +20,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"github.com/golang/mock/gomock"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/metal3-io/ip-address-manager/ipam"
 	ipam_mocks "github.com/metal3-io/ip-address-manager/ipam/mocks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,17 +20,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
-	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	capipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -95,7 +95,7 @@ func lastTag(latestTag string) (string, error) {
 			return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
 		}
 		semVersion.Minor--
-		lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())
+		lastReleaseTag := "v" + semVersion.String()
 		return lastReleaseTag, nil
 	}
 
@@ -106,7 +106,7 @@ func lastTag(latestTag string) (string, error) {
 		return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
 	}
 	semVersion.Patch--
-	lastReleaseTag := fmt.Sprintf("v%s", semVersion.String())
+	lastReleaseTag := "v" + semVersion.String()
 	return lastReleaseTag, nil
 }
 
@@ -150,8 +150,8 @@ func run() int {
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println("Error")
-		fmt.Println(string(out))
+		log.Println("Error")
+		log.Println(string(out))
 		return 1
 	}
 
@@ -211,7 +211,7 @@ func run() int {
 		if body == "" {
 			continue
 		}
-		body = fmt.Sprintf("- %s", body)
+		body = "- " + body
 
 		_, err := fmt.Sscanf(c.merge, "Merge pull request %s from %s", &prNumber, &fork)
 		if err != nil {
@@ -226,43 +226,43 @@ func run() int {
 		merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
 	}
 
-	fmt.Println("<!-- markdownlint-disable no-inline-html line-length -->")
+	log.Println("<!-- markdownlint-disable no-inline-html line-length -->")
 	// TODO Turn this into a link (requires knowing the project name + organization)
-	fmt.Printf("# Changes since %v\n\n", lastTag)
+	log.Printf("# Changes since %v\n\n", lastTag)
 
 	// print the changes by category
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
 		if len(mergeslice) > 0 {
-			fmt.Printf("## %v\n\n", key)
+			log.Printf("## %v\n\n", key)
 			for _, merge := range mergeslice {
-				fmt.Println(merge)
+				log.Println(merge)
 			}
-			fmt.Println()
+			log.Println()
 		}
 
 		// if we're doing beta/rc, print breaking changes and hide the rest of the changes
 		if key == warning {
 			if isBeta(latestTag) {
-				fmt.Printf(warningTemplate, "BETA RELEASE")
+				log.Printf(warningTemplate, "BETA RELEASE")
 			}
 			if isRC(latestTag) {
-				fmt.Printf(warningTemplate, "RELEASE CANDIDATE")
+				log.Printf(warningTemplate, "RELEASE CANDIDATE")
 			}
 			if isBeta(latestTag) || isRC(latestTag) {
-				fmt.Printf("<details>\n")
-				fmt.Printf("<summary>More details about the release</summary>\n\n")
+				log.Printf("<details>\n")
+				log.Printf("<summary>More details about the release</summary>\n\n")
 			}
 		}
 	}
 
 	// then close the details if we had it open
 	if isBeta(latestTag) || isRC(latestTag) {
-		fmt.Printf("</details>\n\n")
+		log.Printf("</details>\n\n")
 	}
 
-	fmt.Printf("The container image for this release is: %v\n", latestTag)
-	fmt.Println("\n_Thanks to all our contributors!_ 😊")
+	log.Printf("The container image for this release is: %v\n", latestTag)
+	log.Println("\n_Thanks to all our contributors!_ 😊")
 
 	return 0
 }
@@ -327,5 +327,5 @@ func getReleaseBranchFromTag(tag string) string {
 	if index := strings.LastIndex(tag, "."); index != -1 {
 		tag = tag[:index]
 	}
-	return fmt.Sprintf("release-%s", tag)
+	return "release-" + tag
 }

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -35,8 +35,7 @@ import (
 )
 
 var (
-	notFoundErr *NotFoundError
-	APIGroup    = "ipam.metal3.io"
+	APIGroup = "ipam.metal3.io"
 )
 
 const (
@@ -95,7 +94,7 @@ func (m *IPPoolManager) SetClusterOwnerRef(cluster *clusterv1.Cluster) error {
 	_, err := findOwnerRefFromList(m.IPPool.OwnerReferences,
 		cluster.TypeMeta, cluster.ObjectMeta)
 	if err != nil {
-		if ok := errors.As(err, &notFoundErr); !ok {
+		if ok := errors.As(err, &errNotFound); !ok {
 			return err
 		}
 		m.IPPool.OwnerReferences, err = setOwnerRefInList(

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -21,10 +21,9 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/ipam/manager_factory_test.go
+++ b/ipam/manager_factory_test.go
@@ -18,10 +18,9 @@ package ipam
 
 import (
 	"github.com/go-logr/logr"
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/ipam/reconcile_error.go
+++ b/ipam/reconcile_error.go
@@ -54,7 +54,7 @@ func (e ReconcileError) Error() string {
 	case TerminalErrorType:
 		return fmt.Sprintf("reconcile error that cannot be recovered occurred: %s. Object will not be requeued", errStr)
 	default:
-		return fmt.Sprintf("reconcile error occurred with unknown recovery type. The actual error is: %s", errStr)
+		return "reconcile error occurred with unknown recovery type. The actual error is: " + errStr
 	}
 }
 

--- a/ipam/reconcile_error_test.go
+++ b/ipam/reconcile_error_test.go
@@ -51,6 +51,6 @@ var _ = Describe("Reconcile Error testing", func() {
 		err := ReconcileError{errors.New("Unknown Error"), "unknownErrorType", 0 * time.Second}
 		Expect(err.IsTerminal()).To(BeFalse())
 		Expect(err.IsTransient()).To(BeFalse())
-		Expect(err.Error()).To(Equal(fmt.Sprintf("reconcile error occurred with unknown recovery type. The actual error is: %s", "Unknown Error")))
+		Expect(err.Error()).To(Equal("reconcile error occurred with unknown recovery type. The actual error is: Unknown Error"))
 	})
 })

--- a/ipam/suite_test.go
+++ b/ipam/suite_test.go
@@ -21,11 +21,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	_ "github.com/go-logr/logr"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/ipam/utils_test.go
+++ b/ipam/utils_test.go
@@ -19,10 +19,9 @@ package ipam
 import (
 	"context"
 
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/main.go
+++ b/main.go
@@ -49,6 +49,14 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
+const (
+	defaultSyncPeriod        = 10 * time.Minute
+	defaultWebhookPort       = 9443
+	defaultIPPoolConcurrency = 10
+	defaultRestConfigQPS     = 20
+	defaultRestConfigBurst   = 30
+)
+
 var (
 	myscheme             = runtime.NewScheme()
 	setupLog             = ctrl.Log.WithName("setup")
@@ -171,9 +179,9 @@ func initFlags(fs *pflag.FlagSet) {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	fs.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile IPAM objects. If unspecified, the controller watches for IPAM objects across all namespaces.")
-	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
+	fs.DurationVar(&syncPeriod, "sync-period", defaultSyncPeriod,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
-	fs.IntVar(&webhookPort, "webhook-port", 9443,
+	fs.IntVar(&webhookPort, "webhook-port", defaultWebhookPort,
 		"Webhook Server port")
 	fs.StringVar(
 		&webhookCertDir,
@@ -190,13 +198,13 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 
-	fs.IntVar(&ippoolConcurrency, "ippool-concurrency", 10,
+	fs.IntVar(&ippoolConcurrency, "ippool-concurrency", defaultIPPoolConcurrency,
 		"Number of ippools to process simultaneously")
 
-	fs.Float64Var(&restConfigQPS, "kube-api-qps", 20,
+	fs.Float64Var(&restConfigQPS, "kube-api-qps", defaultRestConfigQPS,
 		"Maximum queries per second from the controller client to the Kubernetes API server. Default 20")
 
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
+	fs.IntVar(&restConfigBurst, "kube-api-burst", defaultRestConfigBurst,
 		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
 
 	flags.AddManagerOptions(fs, &managerOptions)

--- a/test/fuzz/ippool_controller_fuzzer.go
+++ b/test/fuzz/ippool_controller_fuzzer.go
@@ -2,7 +2,7 @@ package ipam
 
 import (
 	"context"
-	"fmt"
+	"log"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
@@ -23,7 +23,7 @@ func FuzzIPClaimToIPPool(data []byte) int {
 		return 0
 	}
 	r := controller.IPPoolReconciler{}
-	fmt.Printf("tc: %+v\n", tc)
+	log.Printf("tc: %+v\n", tc)
 
 	obj := client.Object(tc.IPClaim)
 	reqs := r.IPClaimToIPPool(context.Background(), obj)

--- a/test/fuzz/ippool_manager_fuzzer.go
+++ b/test/fuzz/ippool_manager_fuzzer.go
@@ -1,7 +1,7 @@
 package ipam
 
 import (
-	"fmt"
+	"log"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"github.com/go-logr/logr"
@@ -18,7 +18,7 @@ func FuzzNewIPPoolManager(data []byte) int {
 		return 0
 	}
 
-	fmt.Printf("before %+v\n", ipPool)
+	log.Printf("before %+v\n", ipPool)
 
 	ipPoolMgr, err := ipam.NewIPPoolManager(nil, ipPool,
 		logr.Discard(),
@@ -28,7 +28,7 @@ func FuzzNewIPPoolManager(data []byte) int {
 	}
 
 	ipPoolMgr.SetFinalizer()
-	fmt.Printf("after %+v\n", ipPool)
+	log.Printf("after %+v\n", ipPool)
 
 	if len(ipPool.ObjectMeta.Finalizers) == 0 {
 		return 0


### PR DESCRIPTION
- Enabled the following linters in `.golangci.yaml`:
  - errname 
  - forbidigo
  - forcetypeassert
  - mnd
  - perfsprint
  - unparam

Fixes: #961
Fixes: #962 
Fixes: #960
Fixes: #965 
Fixes: #966 
Fixes: #967
