### PR TITLE
✨ Adding feature for allocating requested IP

### DIFF
--- a/examples/ippool/ippool.yaml
+++ b/examples/ippool/ippool.yaml
@@ -35,6 +35,8 @@ apiVersion: ipam.metal3.io/v1alpha1
 kind: IPClaim
 metadata:
   name: ${CLUSTER_NAME}-controlplane-template-0-provisioning-pool
+  annotations:
+    ipAddress: <optional-annotation-for-specific-ip-request>
 spec:
   pool:
     name: pool1
@@ -44,6 +46,8 @@ apiVersion: ipam.cluster.x-k8s.io/v1beta1
 kind: IPAddressClaim
 metadata:
   name: ${CLUSTER_NAME}-controlplane-template-1-provisioning-pool
+  annotations:
+    ipAddress: <optional-annotation-for-specific-ip-request>
 spec:
   poolRef:
     apiGroup: ipam.metal3.io

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -1916,6 +1916,125 @@ var _ = Describe("IPPool manager", func() {
 			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
 			expectedPrefix:  24,
 		}),
+		Entry("One pool, with start and existing address, ipAddress annotation present", testCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.16"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation present but already acquired", testCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.11",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectError: true,
+		}),
+
+		Entry("One pool, with start and existing address, ipAddress annotation present and requested ipAddress in preAllocations with conflicting ipclaim name", testCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix: 24,
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.15"),
+					},
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectError: true,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation present and requested ipAddress in preAllocations with non-conflicting ipclaim name", testCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix: 24,
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.16"),
+					},
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.16"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
 		Entry("One pool, with subnet and override prefix", testCaseAllocateAddress{
 			ipPool: &ipamv1.IPPool{
 				Spec: ipamv1.IPPoolSpec{
@@ -2227,6 +2346,124 @@ var _ = Describe("IPPool manager", func() {
 				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
 			},
 			expectedAddress: ipamv1.IPAddressStr("192.168.0.13"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.16"),
+			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+			expectedPrefix:  24,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation but already acquired", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.12",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectError: true,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation present and requested ipAddress in preAllocations with conflicting ipclaim name", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix: 24,
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.15"),
+					},
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectError: true,
+		}),
+		Entry("One pool, with start and existing address, ipAddress annotation present and requested ipAddress in preAllocations with non-conflicting ipclaim name", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix: 24,
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.16"),
+					},
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			},
+			addresses: map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.12"): "bcde",
+				ipamv1.IPAddressStr("192.168.0.11"): "abcd",
+			},
+			expectedAddress: ipamv1.IPAddressStr("192.168.0.16"),
 			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
 			expectedPrefix:  24,
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:
**Requirement**: Allocate a specific to IPAddressClaim or IPClaim when created with special label.
**Solution**: During creation of IPAddressClaim, user can provide a special label i.e. ipAddress: <IP_TO_BE_REQUESTED>. Once IPAddressClaim goes for allocation logic in ip_pool_manager, we can handle the allocation of this IP based on the requestedIP and available IPs.
For a happy path scenario, when allocation is successful, we will create IPAddress with the same IP and update IPPool index with the allocated IP.
For a scenario where user has requested an IP which does not belong to range or not available, we can patch IPAddressClaim CR with the error mentioning the same.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: 
Fixes https://github.com/metal3-io/ip-address-manager/issues/969
