### PR TITLE
:seedling: Fix notes.go so that it still complies with forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -179,6 +179,10 @@ issues:
     - stylecheck
     text: "ST1016: methods on the same type should have the same receiver name"
     path: .*(api|types)\/.*\/conversion.*\.go$
+  - path: notes\.go
+    linters:
+    - forbidigo
+    text: use of `fmt.Printf` forbidden by pattern || use of `fmt.Println` forbidden by pattern
   include:
   - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -226,43 +226,43 @@ func run() int {
 		merges[superseded] = append(merges[superseded], "- `<insert superseded bumps and reverts here>`")
 	}
 
-	log.Println("<!-- markdownlint-disable no-inline-html line-length -->")
+	fmt.Println("<!-- markdownlint-disable no-inline-html line-length -->")
 	// TODO Turn this into a link (requires knowing the project name + organization)
-	log.Printf("# Changes since %v\n\n", lastTag)
+	fmt.Printf("# Changes since %v\n\n", lastTag)
 
 	// print the changes by category
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
 		if len(mergeslice) > 0 {
-			log.Printf("## %v\n\n", key)
+			fmt.Printf("## %v\n\n", key)
 			for _, merge := range mergeslice {
-				log.Println(merge)
+				fmt.Println(merge)
 			}
-			log.Println()
+			fmt.Println()
 		}
 
 		// if we're doing beta/rc, print breaking changes and hide the rest of the changes
 		if key == warning {
 			if isBeta(latestTag) {
-				log.Printf(warningTemplate, "BETA RELEASE")
+				fmt.Printf(warningTemplate, "BETA RELEASE")
 			}
 			if isRC(latestTag) {
-				log.Printf(warningTemplate, "RELEASE CANDIDATE")
+				fmt.Printf(warningTemplate, "RELEASE CANDIDATE")
 			}
 			if isBeta(latestTag) || isRC(latestTag) {
-				log.Printf("<details>\n")
-				log.Printf("<summary>More details about the release</summary>\n\n")
+				fmt.Printf("<details>\n")
+				fmt.Printf("<summary>More details about the release</summary>\n\n")
 			}
 		}
 	}
 
 	// then close the details if we had it open
 	if isBeta(latestTag) || isRC(latestTag) {
-		log.Printf("</details>\n\n")
+		fmt.Printf("</details>\n\n")
 	}
 
-	log.Printf("The container image for this release is: %v\n", latestTag)
-	log.Println("\n_Thanks to all our contributors!_ 😊")
+	fmt.Printf("The container image for this release is: %v\n", latestTag)
+	fmt.Println("\n_Thanks to all our contributors!_ 😊")
 
 	return 0
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Release notes are not being generated in a file when `log` is used. We need to use `fmt` instead but [forbidigo](https://github.com/ashanbrown/forbidigo) complains about using fmt so I added an ignore to the `.golangci.yaml`.

