### PR TITLE
:seedling: add dependabot config for release-1.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,55 @@ updates:
   labels:
   - "ok-to-test"
 ## main branch config ends here
+
+## release-1.10 branch config starts here
+- package-ecosystem: "github-actions"
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "monthly"
+    day: "monday"
+  target-branch: release-1.10
+  ## group all action bumps into single PR
+  groups:
+    github-actions:
+      patterns: ["*"]
+  ignore:
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+  # Go
+- package-ecosystem: "gomod"
+  directories:
+  - "/"
+  - "/api"
+  - "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  target-branch: release-1.10
+  groups:
+    kubernetes:
+      patterns: ["k8s.io/*"]
+    capi:
+      patterns: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"]
+  ignore:
+  # golang.org/x/* only releases minors no patches, so minors have to be allowed
+  - dependency-name: "golang.org/x/*"
+    update-types: ["version-update:semver-major"]
+  # Ignore major and minor bumps for release branch
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
+
+## release-1.10 branch config ends here
+
 ## release-1.9 branch config starts here
 - package-ecosystem: "github-actions"
   directory: "/" # Location of package manifests
@@ -98,52 +147,5 @@ updates:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
+
 ## release-1.9 branch config ends here
-
-## release-1.8 branch config starts here
-- package-ecosystem: "github-actions"
-  directory: "/" # Location of package manifests
-  schedule:
-    interval: "monthly"
-    day: "monday"
-  target-branch: release-1.8
-  ## group all action bumps into single PR
-  groups:
-    github-actions:
-      patterns: ["*"]
-  ignore:
-  # Ignore major and minor bumps for release branch
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-  - "ok-to-test"
-  # Go
-- package-ecosystem: "gomod"
-  directories:
-  - "/"
-  - "/api"
-  - "/hack/tools"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  target-branch: release-1.8
-  groups:
-    kubernetes:
-      patterns: ["k8s.io/*"]
-    capi:
-      patterns: ["sigs.k8s.io/cluster-api", "sigs.k8s.io/cluster-api/test"]
-  ignore:
-  # golang.org/x/* only releases minors no patches, so minors have to be allowed
-  - dependency-name: "golang.org/x/*"
-    update-types: ["version-update:semver-major"]
-  # Ignore major and minor bumps for release branch
-  - dependency-name: "*"
-    update-types: ["version-update:semver-major", "version-update:semver-minor"]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-  - "ok-to-test"
-
-## release-1.8 branch config ends here


### PR DESCRIPTION
Replace release-1.8 config with release-1.10 config. Replace as otherwise it would generate PRs towards 1.8 on merge, which we do not want to handle.
