### PR TITLE
🌱 Bump golang to v1.24

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  go: "1.23"
+  go: "1.24"
 linters:
   disable-all: true
   enable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.23.8@sha256:a5339982f2e78b38b26ebbee35139854e184a4e90e1516f9f636371e720b727b
+ARG BUILD_IMAGE=docker.io/golang:1.24.3@sha256:02a22753ab3426d91ba5ba6f4dfb4ac2454f19b05afdb18d61ab02cbf1a2dffe
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.23.8
+GO_VERSION ?= 1.24.3
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)

--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -29,6 +29,6 @@ else
         --volume "${PWD}:${WORKDIR}:rw,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.24 \
         "${WORKDIR}"/hack/codegen.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -41,6 +41,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.24 \
         "${WORKDIR}"/hack/gomod.sh "$@"
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -19,6 +19,6 @@ else
         --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
-        docker.io/golang:1.22 \
+        docker.io/golang:1.24 \
         "${WORKDIR}"/hack/unit.sh "$@"
 fi


### PR DESCRIPTION
- gomods are still using v1.23.x
- Dockerfile and prow jobs are bumped to use v1.24.3