### PR TITLE
:seedling: Enable variable shadowing check in govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -129,6 +129,9 @@ linters-settings:
     case:
       rules:
         json: goCamel
+  govet:
+    enable:
+    - shadow
 issues:
   exclude-dirs:
   - mock*

--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -73,19 +73,22 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	// Fetch the IPPool instance.
 	ipamv1IPPool := &ipamv1.IPPool{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, ipamv1IPPool); err != nil {
+	var err error
+	var helper *patch.Helper
+
+	if err = r.Client.Get(ctx, req.NamespacedName, ipamv1IPPool); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
-	helper, err := patch.NewHelper(ipamv1IPPool, r.Client)
+	helper, err = patch.NewHelper(ipamv1IPPool, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to init patch helper")
 	}
 	// Always patch ipamv1IPPool exiting this function so we can persist any IPPool changes.
 	defer func() {
-		err := helper.Patch(ctx, ipamv1IPPool)
+		err = helper.Patch(ctx, ipamv1IPPool)
 		if err != nil {
 			metadataLog.Info("failed to Patch ipamv1IPPool")
 			rerr = err

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -311,7 +311,9 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 func (m *IPPoolManager) updateAddress(ctx context.Context,
 	addressClaim *ipamv1.IPClaim, addresses map[ipamv1.IPAddressStr]string,
 ) (_ map[ipamv1.IPAddressStr]string, rerr error) {
-	helper, err := patch.NewHelper(addressClaim, m.client)
+	var err error
+	var helper *patch.Helper
+	helper, err = patch.NewHelper(addressClaim, m.client)
 	if err != nil {
 		return addresses, errors.Wrap(err, "failed to init patch helper")
 	}
@@ -321,7 +323,7 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 		if deleted {
 			return
 		}
-		err := helper.Patch(ctx, addressClaim)
+		err = helper.Patch(ctx, addressClaim)
 		if err != nil {
 			m.Log.Error(err, "failed to Patch IPClaim")
 			rerr = err
@@ -360,13 +362,15 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 func (m *IPPoolManager) capiUpdateAddress(ctx context.Context,
 	addressClaim *capipamv1.IPAddressClaim, addresses map[ipamv1.IPAddressStr]string,
 ) (map[ipamv1.IPAddressStr]string, error) {
-	helper, err := patch.NewHelper(addressClaim, m.client)
+	var err error
+	var helper *patch.Helper
+	helper, err = patch.NewHelper(addressClaim, m.client)
 	if err != nil {
 		return addresses, errors.Wrap(err, "failed to init patch helper")
 	}
 	// Always patch addressClaim exiting this function so we can persist any changes.
 	defer func() {
-		err := helper.Patch(ctx, addressClaim)
+		err = helper.Patch(ctx, addressClaim)
 		if err != nil {
 			m.Log.Error(err, "failed to Patch IPAddressClaim")
 		}

--- a/ipam/utils_test.go
+++ b/ipam/utils_test.go
@@ -110,9 +110,10 @@ var _ = Describe("Metal3 manager utils", func() {
 
 	DescribeTable("Test Update",
 		func(tc testCaseUpdate) {
+			var err error
 			c := k8sClient
 			if tc.ExistingObject != nil {
-				err := c.Create(context.TODO(), tc.ExistingObject)
+				err = c.Create(context.TODO(), tc.ExistingObject)
 				Expect(err).NotTo(HaveOccurred())
 				ipPool := ipamv1.IPClaim{}
 				err = c.Get(context.TODO(),
@@ -126,7 +127,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				tc.TestObject.ObjectMeta = ipPool.ObjectMeta
 			}
 			obj := tc.TestObject.DeepCopy()
-			err := updateObject(context.TODO(), c, obj)
+			err = updateObject(context.TODO(), c, obj)
 			if tc.ExpectedError {
 				Expect(err).To(HaveOccurred())
 				Expect(err).NotTo(BeAssignableToTypeOf(ReconcileError{}))
@@ -145,7 +146,7 @@ var _ = Describe("Metal3 manager utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(savedObject.Spec).To(Equal(tc.TestObject.Spec))
 				Expect(savedObject.ResourceVersion).NotTo(Equal(tc.TestObject.ResourceVersion))
-				err := updateObject(context.TODO(), c, obj)
+				err = updateObject(context.TODO(), c, obj)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(BeAssignableToTypeOf(ReconcileError{}))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable variable shadowing check in govet linter. Fix warnings caused by running the linter.

**Which issue(s) this PR fixes**:
Fixes #1030 