### PR TITLE
🐛 Fix infinite reconciles and timestamp updates

### DIFF
--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -83,16 +84,22 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		}
 		return ctrl.Result{}, err
 	}
+
+	// Deep copy before reconcile
+	original := ipamv1IPPool.DeepCopy()
+
 	helper, err = patch.NewHelper(ipamv1IPPool, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to init patch helper")
 	}
 	// Always patch ipamv1IPPool exiting this function so we can persist any IPPool changes.
 	defer func() {
-		err = helper.Patch(ctx, ipamv1IPPool)
-		if err != nil {
-			metadataLog.Info("failed to Patch ipamv1IPPool")
-			rerr = err
+		if !reflect.DeepEqual(original, ipamv1IPPool) {
+			err = helper.Patch(ctx, ipamv1IPPool)
+			if err != nil {
+				metadataLog.Info("failed to Patch ipamv1IPPool", "error", err)
+				rerr = err
+			}
 		}
 	}()
 

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -207,6 +207,9 @@ func (m *IPPoolManager) updateStatusTimestamp() {
 // It returns the number of current allocations. Current allocation include
 // both capi and metal3 type ipaddress objects.
 func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
+	if m.IPPool.Status.LastUpdated == nil {
+		m.IPPool.Status.LastUpdated = m.IPPool.CreationTimestamp.DeepCopy()
+	}
 	_, err := m.m3UpdateAddresses(ctx)
 	if err != nil {
 		return 0, err
@@ -215,7 +218,6 @@ func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-
 	return count, nil
 }
 
@@ -259,7 +261,6 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 			return 0, err
 		}
 	}
-	m.updateStatusTimestamp()
 	return len(addresses), nil
 }
 
@@ -301,7 +302,6 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 			return 0, err
 		}
 	}
-	m.updateStatusTimestamp()
 	return len(addresses), nil
 }
 

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -703,7 +703,7 @@ var _ = Describe("IPPool manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 			Expect(nbAllocations).To(Equal(tc.expectedNbAllocations))
-			Expect(tc.ipPool.Status.LastUpdated.IsZero()).To(BeFalse())
+			Expect(tc.ipPool.Status.LastUpdated).ToNot(BeNil())
 			Expect(tc.ipPool.Status.Allocations).To(Equal(tc.expectedAllocations))
 
 			// get list of IPAddress objects


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Patch only when IPPool is changed.
- Removed unnecessary m.updateStatusTimestamp() calls
NOTE: In API it says:
	`// LastUpdated identifies when this status was last observed.`
This seems wrong, firstly I dont think its idea to update something in ippool every time it is observed and secondly even if we are doing it its not named properly. We should change the this text.
- When pool is created for the first time, `IPPool.Status.LastUpdated` is same as `IPPool.CreationTimestamp`. `IPPool.Status.LastUpdated` will only be updated when there is actual change in the ippool which we are doing here: https://github.com/metal3-io/ip-address-manager/blob/main/ipam/ippool_manager.go#L195


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/metal3-io/ip-address-manager/issues/1071
