### PR TITLE
🌱 Add continue-on-error and improve Slack notifications for osv-scanner

### DIFF
--- a/.github/workflows/osv-scanner-scan.yml
+++ b/.github/workflows/osv-scanner-scan.yml
@@ -53,9 +53,10 @@ jobs:
       uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d # v3.29.5
       with:
         sarif_file: results.sarif
-    # if the results.json has any results, then it means there is some vulnerability to be checked out
+      continue-on-error: true
+    # Send notification if vulnerabilities found or any step failed
     - name: Slack Notification on Failure
-      if: ${{ steps.osv-scan.outputs.has_vulnerabilities == 'true' }}
+      if: ${{ steps.osv-scan.outputs.has_vulnerabilities == 'true' || failure() }}
       uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # 2.3.3
       env:
         SLACK_TITLE: "OSV-Scanner detected vulnerabilities in ${{ github.repository }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The osv-scanner workflow should continue on error when uploading SARIF files and send Slack notifications for both vulnerabilities and workflow failures.

This ensures we get notified of any issues with the workflow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
