### PR TITLE
🌱Uplift go 1.24.8 to address CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Support FROM override
-ARG BUILD_IMAGE=docker.io/golang:1.24.7@sha256:5e9d14d681c3224276f0c8e318525ef6fc96b47fbcbb89f8bec0e402e18ea8bf
+ARG BUILD_IMAGE=docker.io/golang:1.24.8@sha256:dd80b4158d9c4ca750687719d1a4b79ec9f78f19c4b87b53b73d552ceccfb7a8
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
 
 # Build the manager binary on golang image

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.24.7
+GO_VERSION ?= 1.24.8
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)


### PR DESCRIPTION
Uplift go 1.24.8 to address the security vulnerabilities. These minor releases include PRIVATE security fixes to the standard library, covering the following CVEs: [announcement](https://groups.google.com/g/golang-announce/c/ask65OnfzGU)
CVE-2025-61724
CVE-2025-61725
CVE-2025-58187
CVE-2025-61723
CVE-2025-47912
CVE-2025-58185
CVE-2025-58186
CVE-2025-58188
CVE-2025-58183