### PR TITLE
🌱 Migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,8 +32,8 @@ jobs:
       with:
         go-version: ${{ steps.vars.outputs.go_version }}
     - name: golangci-lint-${{matrix.working-directory}}
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v1.64.7
+        version: v2.1.0
         working-directory: ${{matrix.working-directory}}
         args: --timeout=10m ${{matrix.additional-args}}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,9 @@
+version: "2"
 run:
+  # Run without --fast-only flag for more extensive checks
   go: "1.24"
 linters:
-  disable-all: true
+  default: none
   enable:
   - asasalint
   - asciicheck
@@ -23,20 +25,16 @@ linters:
   - fatcontext
   - forbidigo
   - forcetypeassert
-  - gci
   - ginkgolinter
   - gocheckcompilerdirectives
   - gochecksumtype
   - goconst
   - gocritic
   - godot
-  - gofmt
-  - goimports
   - goprintffuncname
   - gosec
-  - gosimple
   - gosmopolitan
-  - govet
+  - govet         # v2 runs typecheck via govet, so the standalone typecheck linter is not needed
   - iface
   - importas
   - ineffassign
@@ -59,151 +57,181 @@ linters:
   - reassign
   - revive
   - rowserrcheck
-  - staticcheck
-  - stylecheck
+  - staticcheck # includes gosimple/stylecheck analyzers in v2
   - tagliatelle
   - testifylint
   - thelper
   - tparallel
-  - typecheck
   - unconvert
   - unparam
   - unused
   - usestdlibvars
   - usetesting
   - whitespace
-  # Run with --fast=false for more extensive checks
-  fast: true
-
-linters-settings:
-  gosec:
-    severity: medium
-    confidence: medium
-    concurrency: 8
-  importas:
-    no-unaliased: true
-    alias:
-    # Kubernetes
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
-    - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-      alias: apiextensionsv1
-    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-      alias: metav1
-    - pkg: k8s.io/apimachinery/pkg/api/errors
-      alias: apierrors
-    # Controller Runtime
-    - pkg: sigs.k8s.io/controller-runtime
-      alias: ctrl
-    - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
-      alias: clusterv1alpha4
-    - pkg: sigs.k8s.io/cluster-api/api/v1beta2
-      alias: clusterv1
-    - pkg: sigs.k8s.io/cluster-api/api/core/v1beta1
-      alias: clusterv1beta1
-    - pkg: sigs.k8s.io/cluster-api/api/ipam/v1beta1
-      alias: capipamv1beta1
-    # IPAM
-    - pkg: github.com/metal3-io/ip-address-manager/api/v1alpha1
-      alias: ipamv1
-  nolintlint:
-    allow-unused: false
-    require-specific: true
-  gocritic:
-    enabled-tags:
-    - experimental
-    disabled-checks:
-    - appendAssign
-    - dupImport # https://github.com/go-critic/go-critic/issues/845
-    - evalOrder
-    - ifElseChain
-    - octalLiteral
-    - regexpSimplify
-    - sloppyReassign
-    - truncateCmp
-    - typeDefFirst
-    - unnamedResult
-    - unnecessaryDefer
-    - whyNoLint
-    - wrapperFunc
-  ginkgolinter:
-    forbid-focus-container: true
-    force-expect-to: true
-  tagliatelle:
-    case:
-      rules:
-        json: goCamel
-  govet:
-    enable:
-    - shadow
+  settings:
+    ginkgolinter:
+      forbid-focus-container: true
+      force-expect-to: true
+    gocritic:
+      disabled-checks:
+      - appendAssign
+      - dupImport   # https://github.com/go-critic/go-critic/issues/845
+      - evalOrder
+      - ifElseChain
+      - octalLiteral
+      - regexpSimplify
+      - sloppyReassign
+      - truncateCmp
+      - typeDefFirst
+      - unnamedResult
+      - unnecessaryDefer
+      - whyNoLint
+      - wrapperFunc
+      enabled-tags:
+      - experimental
+    gosec:
+      severity: medium
+      confidence: medium
+      concurrency: 8
+    govet:
+      enable:
+      - shadow
+    importas:
+      alias:
+        # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+        # Controller Runtime
+      - pkg: sigs.k8s.io/controller-runtime
+        alias: ctrl
+      - pkg: sigs.k8s.io/cluster-api/api/v1alpha4
+        alias: clusterv1alpha4
+      - pkg: sigs.k8s.io/cluster-api/api/v1beta2
+        alias: clusterv1
+      - pkg: sigs.k8s.io/cluster-api/api/core/v1beta1
+        alias: clusterv1beta1
+      - pkg: sigs.k8s.io/cluster-api/api/ipam/v1beta1
+        alias: capipamv1beta1
+        # IPAM
+      - pkg: github.com/metal3-io/ip-address-manager/api/v1alpha1
+        alias: ipamv1
+      no-unaliased: true
+    nolintlint:
+      require-specific: true
+      allow-unused: false
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+  exclusions:
+    generated: lax
+    presets:
+    - comments
+    - common-false-positives
+    - legacy
+    - std-error-handling
+    rules:
+    - linters:
+      - dupl
+      - unused
+      path: _test\.go
+      # Disable linters for conversion
+    - linters:
+      - staticcheck
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: 'SA1019:'
+      # Dot imports for gomega or ginkgo are allowed 
+      # within test files.
+    - path: _test\.go
+      text: should not use dot imports
+    - path: (test|e2e)/.*.go
+      text: should not use dot imports
+    - linters:
+      - staticcheck
+      text: 'SA1019: "sigs.k8s.io/cluster-api/api/core/v1beta1" is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
+    - linters:
+      - staticcheck
+      text: 'SA1019: "sigs.k8s.io/cluster-api/api/ipam/v1beta1" is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
+    - linters:
+      - staticcheck
+      text: 'SA1019: "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/.*" is deprecated'
+    - linters:
+      - revive
+      text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
+      # Exclude some packages or code to require comments, for example test code, or fake clients.
+    - linters:
+      - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      source: (func|type).*Fake.*
+    - linters:
+      - revive
+      path: fake_\.go
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+    - linters:
+      - revive
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+    - linters:
+      - revive
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: 'var-naming: don''t use underscores in Go names;'
+    - linters:
+      - revive
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: 'receiver-naming: receiver name'
+    - linters:
+      - staticcheck
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: 'ST1003: should not use underscores in Go names;'
+    - linters:
+      - staticcheck
+      path: .*(api|types)\/.*\/conversion.*\.go$
+      text: 'ST1016: methods on the same type should have the same receiver name'
+    - linters:
+      - staticcheck
+      text: 'QF1004: could use strings.ReplaceAll instead'
+    - linters:
+      - staticcheck
+      text: 'QF1008: could remove embedded field .* from selector'
+    - linters:
+      - staticcheck
+      text: 'QF1007: could merge conditional assignment into variable declaration'
+    - linters:
+      - forbidigo
+      path: notes\.go
+      text: use of `fmt.Printf` forbidden by pattern || use of `fmt.Println` forbidden by pattern
+    paths:
+    - zz_generated.*\.go$
+    - .*conversion.*\.go$
+    - mock*
+    - third_party$
+    - builtin$
+    - examples$
 issues:
-  exclude-dirs:
-  - mock*
-  exclude-files:
-  - "zz_generated.*\\.go$"
-  - ".*conversion.*\\.go$"
-  exclude-rules:
-  - path: _test\.go
-    linters:
-    - unused
-    - dupl
-  # Disable linters for conversion
-  - linters:
-    - staticcheck
-    text: "SA1019:"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  # Dot imports for gomega or ginkgo are allowed
-  # within test files.
-  - path: _test\.go
-    text: should not use dot imports
-  - path: (test|e2e)/.*.go
-    text: should not use dot imports
-  - linters:
-    - staticcheck
-    text: 'SA1019: "sigs.k8s.io/cluster-api/api/core/v1beta1" is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
-  - linters:
-    - staticcheck
-    text: 'SA1019: "sigs.k8s.io/cluster-api/api/ipam/v1beta1" is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
-  - linters:
-    - staticcheck
-    text: 'SA1019: "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/.*" is deprecated'
-  - linters:
-    - revive
-    text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-  # Exclude some packages or code to require comments, for example test code, or fake clients.
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    source: (func|type).*Fake.*
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: fake_\.go
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - revive
-    text: "var-naming: don't use underscores in Go names;"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - revive
-    text: "receiver-naming: receiver name"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - stylecheck
-    text: "ST1003: should not use underscores in Go names;"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - stylecheck
-    text: "ST1016: methods on the same type should have the same receiver name"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - path: notes\.go
-    linters:
-    - forbidigo
-    text: use of `fmt.Printf` forbidden by pattern || use of `fmt.Println` forbidden by pattern
-  include:
-  - EXC0002 # include "missing comments" issues from golangci-lint
+  # Legacy (v1): `issues.include` is deprecated in v2; original config kept for reference:
+  #   include:
+  #     - EXC0002 # include "missing comments" issues from golangci-lint
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  # v2 migrates gci/gofmt/goimports into the formatter pipeline,
+  # so they no longer sit under linters.enable.
+  enable:
+  - gci
+  - gofmt
+  - goimports
+  exclusions:
+    generated: lax
+    paths:
+    - zz_generated.*\.go$
+    - .*conversion.*\.go$
+    - mock*
+    - third_party$
+    - builtin$
+    - examples$

--- a/Makefile
+++ b/Makefile
@@ -143,18 +143,18 @@ $(KUSTOMIZE): $(TOOLS_DIR)/go.mod
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	$(GOLANGCI_LINT) run -v --fast-only $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v --fast-only $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --fast-only --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
-	$(GOLANGCI_LINT) run -v --fast=false
-	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v --fast=false --timeout=30m
-	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --fast=false --build-tags=tools --modules-download-mode=readonly --timeout=30m
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
+	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
+	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
 
 ## --------------------------------------
 ## Generate

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -60,10 +60,10 @@ download_and_install_golangci_lint()
     KERNEL_OS="$(uname | tr '[:upper:]' '[:lower:]')"
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
-    GOLANGCI_VERSION="1.64.7"
+    GOLANGCI_VERSION="2.1.0"
     case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="9ff4b40bd4c8cd199d010c0e96e424416c32827fce0fb7eedebb48294106623b" ;;
-        linux-amd64) GOLANGCI_SHA256="dada4095eab53f868f931840f04b99cb4be654e45f50d4d3b2832dc9ad3bede8" ;;
+        darwin-arm64) GOLANGCI_SHA256="88eb4d7d1761fc39e6cc4e90e12fa8167739354507a137cac678c8246a8f5888" ;;
+        linux-amd64) GOLANGCI_SHA256="ef8211a45a23c067f6ef4d9cf8cb4dd9db165c3586e2472b5f499177b6e784b1" ;;
       *)
         echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
         exit 1


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

Hello 👋  This PR migrates the golangci-lint tooling to v2.1.0 with the cli command:

``` bash
$ golangci-lint migrate
```

In addition, I migrated the Github workflow `.github/workflows/golangci-lint.yml` and the helper script `hack/ensure-golangci-lint.sh`  to version 2.1.0.

Now 
1. `make lint`: uses `--fast-only` (matching the new golangci-lint v2 semantics with the v1) 
2.  `make lint-full`: dropped the obsolete `--fast=false` to run the complete set without extra flags.


In addition, `make lint-full` resulted in 19 new staticcheck issues.

```
19 issues:
* staticcheck: 19
INFO File cache stats: 10 entries of total size 77.5KiB 
INFO Memory: 119 samples, avg is 1886.2MB, max is 3424.3MB 
INFO Execution took 11.72116225s                  
make: *** [lint] Error 1
```

Since they are mainly related to styling, I added exceptions (QF1008 and QF1004) to make the tests pass. 

**Which issue(s) this PR fixes** :
Fixes #1157

I don't know if the Checklist is applicable in this case

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
