### PR TITLE
:sparkles: add image SBOM attestation to image builds

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -30,11 +30,15 @@ jobs:
     needs: set_ref
     name: Build IPAM container image
     if: github.repository == 'metal3-io/ip-address-manager'
+    permissions:
+      contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
     with:
       image-name: "ip-address-manager"
       pushImage: true
       ref: ${{ needs.set_ref.outputs.github_ref }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,6 +122,7 @@ jobs:
   build_ipam:
     permissions:
       contents: read
+      id-token: write
     needs: push_release_tags
     name: Build IPAM container image
     if: github.repository == 'metal3-io/ip-address-manager'
@@ -130,6 +131,7 @@ jobs:
       image-name: "ip-address-manager"
       pushImage: true
       ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Use reusable container build workflow from project-infra to enable image SBOM attestations to be attached to the image digest when any IPAM image is built.

For this, we need id-token permission for keyless signing and enabling the SBOM generation via flag.
