### PR TITLE
🌱 improve ip address validation

### DIFF
--- a/internal/webhooks/v1alpha1/ipclaim_webhook.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook.go
@@ -68,6 +68,19 @@ func (webhook *IPClaim) ValidateCreate(_ context.Context, obj runtime.Object) (a
 		)
 	}
 
+	// Validate requested IP address if present in annotations
+	if requestedIP, ok := c.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
+		if err := validateIP(ipamv1.IPAddressStr(requestedIP)); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("metadata", "annotations", "ipAddress"),
+					requestedIP,
+					"is not a valid IP address",
+				),
+			)
+		}
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
@@ -111,6 +124,19 @@ func (webhook *IPClaim) ValidateUpdate(_ context.Context, oldObj, newObj runtime
 				"cannot be modified",
 			),
 		)
+	}
+
+	// Validate requested IP address if present in annotations
+	if requestedIP, ok := newIPClaim.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
+		if err := validateIP(ipamv1.IPAddressStr(requestedIP)); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("metadata", "annotations", "ipAddress"),
+					requestedIP,
+					"is not a valid IP address",
+				),
+			)
+		}
 	}
 
 	if len(allErrs) == 0 {

--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -16,6 +16,7 @@ limitations under the License.
 package webhooks
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,6 +32,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+func validateIP(s ipamv1.IPAddressStr) error {
+	if s == "" {
+		return nil
+	}
+	if net.ParseIP(string(s)) == nil {
+		return fmt.Errorf("invalid IP address: %q", s)
+	}
+	return nil
+}
 
 func (webhook *IPPool) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -55,12 +66,16 @@ func (webhook *IPPool) Default(_ context.Context, _ runtime.Object) error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *IPPool) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
-	_, ok := obj.(*ipamv1.IPPool)
+	m3ipp, ok := obj.(*ipamv1.IPPool)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a IPPool but got a %T", obj))
 	}
 
-	return nil, nil
+	allErrs := webhook.validatePoolRanges(m3ipp)
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+	return nil, apierrors.NewInvalid(ipamv1.GroupVersion.WithKind("IPPool").GroupKind(), m3ipp.Name, allErrs)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
@@ -85,6 +100,10 @@ func (webhook *IPPool) ValidateUpdate(_ context.Context, oldObj, newObj runtime.
 			),
 		)
 	}
+
+	// Validate the new pool ranges
+	allErrs = append(allErrs, webhook.validatePoolRanges(newM3ipp)...)
+
 	allocationOutOfBonds, inUseOutOfBonds := webhook.checkPoolBonds(oldM3ipp, newM3ipp)
 	if len(allocationOutOfBonds) != 0 {
 		for _, address := range allocationOutOfBonds {
@@ -179,6 +198,136 @@ func (webhook *IPPool) isAddressInBonds(newPool *ipamv1.IPPool, address ipamv1.I
 	}
 
 	return false
+}
+
+// validatePoolRanges validates that start <= end for each pool and validates all IP addresses.
+func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Validate gateway IP if present
+	if pool.Spec.Gateway != nil {
+		if err := validateIP(*pool.Spec.Gateway); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "gateway"),
+					*pool.Spec.Gateway,
+					"is not a valid IP address",
+				),
+			)
+		}
+	}
+
+	// Validate DNS server IPs
+	for i, dnsServer := range pool.Spec.DNSServers {
+		if err := validateIP(dnsServer); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "dnsServers").Index(i),
+					dnsServer,
+					"is not a valid IP address",
+				),
+			)
+		}
+	}
+
+	// Validate preAllocations IPs
+	for name, ipAddr := range pool.Spec.PreAllocations {
+		if err := validateIP(ipAddr); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "preAllocations", name),
+					ipAddr,
+					"is not a valid IP address",
+				),
+			)
+		}
+	}
+
+	for i, pool := range pool.Spec.Pools {
+		// Validate Start IP
+		if pool.Start != nil {
+			if err := validateIP(*pool.Start); err != nil {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "pools").Index(i).Child("start"),
+						*pool.Start,
+						"is not a valid IP address",
+					),
+				)
+			}
+		}
+
+		// Validate End IP
+		if pool.End != nil {
+			if err := validateIP(*pool.End); err != nil {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "pools").Index(i).Child("end"),
+						*pool.End,
+						"is not a valid IP address",
+					),
+				)
+			}
+		}
+
+		// Validate Subnet CIDR
+		if pool.Subnet != nil {
+			if _, _, err := net.ParseCIDR(string(*pool.Subnet)); err != nil {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "pools").Index(i).Child("subnet"),
+						*pool.Subnet,
+						"is not a valid CIDR",
+					),
+				)
+			}
+		}
+
+		// Validate pool-specific gateway IP
+		if pool.Gateway != nil {
+			if err := validateIP(*pool.Gateway); err != nil {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "pools").Index(i).Child("gateway"),
+						*pool.Gateway,
+						"is not a valid IP address",
+					),
+				)
+			}
+		}
+
+		// Validate pool-specific DNS server IPs
+		for j, dnsServer := range pool.DNSServers {
+			if err := validateIP(dnsServer); err != nil {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "pools").Index(i).Child("dnsServers").Index(j),
+						dnsServer,
+						"is not a valid IP address",
+					),
+				)
+			}
+		}
+		// Validate start <= end if both are present and valid
+		if pool.Start != nil && pool.End != nil {
+			startIP := net.ParseIP(string(*pool.Start))
+			endIP := net.ParseIP(string(*pool.End))
+
+			// Only compare if both IPs parsed successfully
+			if startIP != nil && endIP != nil {
+				if bytes.Compare(startIP, endIP) > 0 {
+					allErrs = append(allErrs,
+						field.Invalid(
+							field.NewPath("spec", "pools").Index(i),
+							fmt.Sprintf("start: %s, end: %s", *pool.Start, *pool.End),
+							"start address must be less than or equal to end address",
+						),
+					)
+				}
+			}
+		}
+	}
+	return allErrs
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Improve ip address validation. IP address string format is forced with kubebuilder when creating custom resources. No validation is done when IPClaims and IPPools are create with code. I suggest adding more rigorous validation to force ip addresses to be the correct format.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #1244

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
