### PR TITLE
🌱 replace pkg/errors with stdlib Errorf

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 require (
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.39.0
-	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
 	k8s.io/klog/v2 v2.130.1
@@ -40,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -17,18 +17,17 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
-
-	"github.com/pkg/errors"
 )
 
 // GetIPAddress renders the IP address, taking the index, offset and step into
 // account, it is IP version agnostic.
 func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
 	if entry.Start == nil && entry.Subnet == nil {
-		return "", errors.New("Either Start or Subnet is required for ipAddress")
+		return "", errors.New("either Start or Subnet is required for ipAddress")
 	}
 	var ip net.IP
 	var err error

--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -18,13 +18,14 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/metal3-io/ip-address-manager/ipam"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,7 +91,7 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 
 	helper, err = patch.NewHelper(ipamv1IPPool, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to init patch helper")
+		return ctrl.Result{}, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 	// Always patch ipamv1IPPool exiting this function so we can persist any IPPool changes.
 	defer func() {
@@ -131,7 +132,7 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	// Create a helper for managing the metadata object.
 	ipPoolMgr, err := r.ManagerFactory.NewIPPoolManager(ipamv1IPPool, metadataLog)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the IP pool")
+		return ctrl.Result{}, fmt.Errorf("failed to create helper for managing the IP pool: %w", err)
 	}
 
 	if ipamv1IPPool.Spec.ClusterName != nil && cluster != nil && cluster.Name != "" {
@@ -271,7 +272,7 @@ func checkReconcileError(err error, errMessage string) (ctrl.Result, error) {
 			return reconcile.Result{}, nil
 		}
 	}
-	return ctrl.Result{}, errors.Wrap(err, errMessage)
+	return ctrl.Result{}, fmt.Errorf("%s: %w", errMessage, err)
 }
 
 // IsPaused returns true if the Cluster is paused or the object has the `paused` annotation.

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -26,7 +27,6 @@ import (
 	ipam_mocks "github.com/metal3-io/ip-address-manager/ipam/mocks"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/metal3-io/ip-address-manager/api v0.0.0
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.39.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.10
 	k8s.io/api v0.34.3
 	k8s.io/apiextensions-apiserver v0.34.3
@@ -60,6 +59,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.34.0
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.0
 )
@@ -43,6 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/onsi/gomega v1.37.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/github"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
@@ -92,7 +92,7 @@ func lastTag(latestTag string) (string, error) {
 
 		semVersion, err := semver.New(latestTag)
 		if err != nil {
-			return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
+			return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
 		}
 		semVersion.Minor--
 		lastReleaseTag := "v" + semVersion.String()
@@ -103,7 +103,7 @@ func lastTag(latestTag string) (string, error) {
 
 	semVersion, err := semver.New(latestTag)
 	if err != nil {
-		return "", errors.Wrapf(err, "parsing semver for %s", latestTag)
+		return "", fmt.Errorf("parsing semver for %s: %w", latestTag, err)
 	}
 	semVersion.Patch--
 	lastReleaseTag := "v" + semVersion.String()

--- a/internal/webhooks/v1alpha1/ipaddress_webhook.go
+++ b/internal/webhooks/v1alpha1/ipaddress_webhook.go
@@ -17,10 +17,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/internal/webhooks/v1alpha1/ipclaim_webhook.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook.go
@@ -17,10 +17,10 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -17,13 +17,13 @@ package webhooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
 	"reflect"
 
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/ipam/utils.go
+++ b/ipam/utils.go
@@ -18,10 +18,10 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -63,7 +63,7 @@ func (e *NotFoundError) Error() string {
 func deepCopyObject(obj client.Object) (client.Object, error) {
 	objCopy, ok := obj.DeepCopyObject().(client.Object)
 	if !ok {
-		return nil, errors.New("Failed to copy object")
+		return nil, errors.New("failed to copy object")
 	}
 	return objCopy, nil
 }
@@ -75,7 +75,7 @@ func updateObject(ctx context.Context, cl client.Client, obj client.Object) erro
 	}
 	err = cl.Update(ctx, objCopy)
 	if apierrors.IsConflict(err) {
-		return WithTransientError(errors.New("Updating object failed"), 0*time.Second)
+		return WithTransientError(errors.New("updating object failed"), 0*time.Second)
 	}
 	return err
 }
@@ -88,7 +88,7 @@ func createObject(ctx context.Context, cl client.Client, obj client.Object, opts
 	err = cl.Create(ctx, objCopy, opts...)
 	if apierrors.IsAlreadyExists(err) {
 		log.Printf("I am inside IsAlreadyExists")
-		return WithTransientError(errors.New("Object already exists"), 0*time.Second)
+		return WithTransientError(errors.New("object already exists"), 0*time.Second)
 	}
 	return err
 }


### PR DESCRIPTION
Cleanup one direct dependency by using stdlib Errorf instead. We're not utilizing any functionality from pkg/errors.