### PR TITLE
🌱 rename lint-full -> lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,18 +143,13 @@ $(KUSTOMIZE): $(TOOLS_DIR)/go.mod
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v --fast-only $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v --fast-only $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
-	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --fast-only --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
+	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=10m
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
-
-lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
-	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
-	cd $(APIS_DIR); ../$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
-	cd $(TOOLS_DIR)/release; ../../../$(GOLANGCI_LINT) run -v --build-tags=tools --modules-download-mode=readonly $(GOLANGCI_LINT_EXTRA_ARGS) --timeout=30m
 
 ## --------------------------------------
 ## Generate


### PR DESCRIPTION
Our github workflow for golangci-lint matches lint-full, so its quite confusing and not really productive to separate between full and fast, as the difference is like 1s.
