### PR TITLE
:bug: Revert listing limits

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -44,7 +44,6 @@ const (
 	IPAddressClaimFinalizer = "ipam.metal3.io/ipaddressclaim"
 	IPAddressFinalizer      = "ipam.metal3.io/ipaddress"
 	IPAddressAnnotation     = "ipAddress"
-	defaultListLimit        = 200
 )
 
 // IPPoolManagerInterface is an interface for a IPPoolManager.
@@ -160,7 +159,6 @@ func (m *IPPoolManager) getIndexes(ctx context.Context) (map[ipamv1.IPAddressStr
 	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
 		Namespace: m.IPPool.Namespace,
-		Limit:     defaultListLimit,
 	}
 
 	err := m.client.List(ctx, &addressObjects, opts)
@@ -260,7 +258,6 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
 		Namespace: m.IPPool.Namespace,
-		Limit:     defaultListLimit,
 	}
 
 	err = m.client.List(ctx, &addressClaimObjects, opts)
@@ -302,7 +299,6 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 	// without this ListOption, all namespaces would be including in the listing
 	opts := &client.ListOptions{
 		Namespace: m.IPPool.Namespace,
-		Limit:     defaultListLimit,
 	}
 
 	err = m.client.List(ctx, &addressClaimObjects, opts)


### PR DESCRIPTION
It seems that limiting the listing to 200 wasn't the best number, specifically for cases when there is more objects than 200 on the same namespace. Revert it for now and instead we improve the filtering the objects during fetch.

Related to https://github.com/metal3-io/cluster-api-provider-metal3/issues/2924. 