### PR TITLE
:seedling: Remove TLS minimum version configuration from manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,6 @@ spec:
         - "--webhook-port=9443"
         - "--diagnostics-address=${IPAM_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${IPAM_INSECURE_DIAGNOSTICS:=false}"
-        - "--tls-min-version=${TLS_MIN_VERSION:=VersionTLS13}"
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
Restore TLS default to no configuration in production. I've opened a corresponding PR in  CAPM3 where TLS is removed as the production default but is enabled trough kustomization in e2e testing: https://github.com/metal3-io/cluster-api-provider-metal3/pull/3187

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
