### PR TITLE
:bug: remove unused RBAC permissions for secrets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,18 +16,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews

--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -66,7 +66,6 @@ type IPPoolReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/status,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile handles IPPool events.
 func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
@@ -175,7 +174,7 @@ func (r *IPPoolReconciler) reconcileDelete(ctx context.Context,
 ) (ctrl.Result, error) {
 	allocationsNb, err := ipPoolMgr.UpdateAddresses(ctx)
 	if err != nil {
-		return checkReconcileError(err, "Failed to delete the old secrets")
+		return checkReconcileError(err, "Failed to delete the old addresses")
 	}
 
 	if allocationsNb == 0 {

--- a/main.go
+++ b/main.go
@@ -29,9 +29,7 @@ import (
 	"github.com/metal3-io/ip-address-manager/ipam"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -114,9 +112,6 @@ func main() {
 		}
 	}
 
-	req, _ := labels.NewRequirement(clusterv1beta1.ClusterNameLabel, selection.Exists, nil)
-	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
-
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = float32(restConfigQPS)
 	restConfig.Burst = restConfigBurst
@@ -130,20 +125,11 @@ func main() {
 		Cache: cache.Options{
 			DefaultNamespaces: watchNamespaces,
 			SyncPeriod:        &syncPeriod,
-			ByObject: map[client.Object]cache.ByObject{
-				// Note: Only Secrets with the cluster name label are cached.
-				// The default client of the manager won't use the cache for secrets at all (see Client.Cache.DisableFor).
-				// The cached secrets will only be used by the secretCachingClient we create below.
-				&corev1.Secret{}: {
-					Label: clusterSecretCacheSelector,
-				},
-			},
 		},
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
 					&corev1.ConfigMap{},
-					&corev1.Secret{},
 				},
 			},
 		},


### PR DESCRIPTION
Remove the kubebuilder RBAC marker granting full CRUD on secrets. The controller never accesses secrets. Also remove the dead secret cache configuration and stale secretCachingClient comment from main.go.

Manual cherry-pick of PR #1355.
