### PR TITLE
✨ Add random IP allocation strategy to IPPool

### DIFF
--- a/api/v1alpha1/ippool_types.go
+++ b/api/v1alpha1/ippool_types.go
@@ -26,6 +26,16 @@ const (
 	IPPoolFinalizer = "ippool.ipam.metal3.io"
 )
 
+// AllocationStrategy defines the strategy for IP address allocation from a pool.
+type AllocationStrategy string
+
+const (
+	// AllocationStrategySequential allocates IPs sequentially from pools (default).
+	AllocationStrategySequential AllocationStrategy = "sequential"
+	// AllocationStrategyRandom allocates IPs randomly from available pool addresses.
+	AllocationStrategyRandom AllocationStrategy = "random"
+)
+
 // MetaDataIPAddress contains the info to render th ip address. It is IP-version
 // agnostic.
 type Pool struct {
@@ -61,6 +71,16 @@ type IPPoolSpec struct {
 
 	// Pools contains the list of IP addresses pools
 	Pools []Pool `json:"pools,omitempty"`
+
+	// +kubebuilder:default=sequential
+	// +kubebuilder:validation:Enum=sequential;random
+	// AllocationStrategy defines how IP addresses are allocated from the pools.
+	// "sequential" (default) allocates the first available IP.
+	// "random" allocates a random available IP.
+	// In both strategies, multiple pools are consumed in declaration order: a
+	// pool is fully exhausted before the next one is used, and the strategy only
+	// changes how an address is selected within a single pool.
+	AllocationStrategy AllocationStrategy `json:"allocationStrategy,omitempty"`
 
 	// PreAllocations contains the preallocated IP addresses
 	PreAllocations map[string]IPAddressStr `json:"preAllocations,omitempty"`

--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
 )
@@ -74,6 +75,106 @@ func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
 		}
 	}
 	return IPAddressStr(ip.String()), nil
+}
+
+// ValidatePool validates the address-range fields of a single pool entry: that
+// any Start/End/Subnet values present are well-formed, and that start <= end
+// when both Start and End are set. It is intentionally lenient about presence
+// (a Start-only or End-only pool is valid for the sequential strategy), so it
+// does not require Start or Subnet to be set and does not bound-check the size.
+// It is the shared validation used by both the webhook and GetPoolSize so the
+// range/format checks live in a single place.
+func ValidatePool(entry Pool) error {
+	var startIP, endIP net.IP
+
+	if entry.Start != nil {
+		startIP = net.ParseIP(string(*entry.Start))
+		if startIP == nil {
+			return fmt.Errorf("invalid Start IP %q", *entry.Start)
+		}
+	}
+	if entry.End != nil {
+		endIP = net.ParseIP(string(*entry.End))
+		if endIP == nil {
+			return fmt.Errorf("invalid End IP %q", *entry.End)
+		}
+	}
+	if entry.Subnet != nil {
+		if _, _, err := net.ParseCIDR(string(*entry.Subnet)); err != nil {
+			return fmt.Errorf("invalid Subnet %q: %w", *entry.Subnet, err)
+		}
+	}
+	if startIP != nil && endIP != nil {
+		if new(big.Int).SetBytes(startIP.To16()).Cmp(new(big.Int).SetBytes(endIP.To16())) > 0 {
+			return fmt.Errorf("end IP %s is before start IP %s", endIP, startIP)
+		}
+	}
+	return nil
+}
+
+// GetPoolSize returns the number of indexable IP addresses in the given pool
+// entry, matching the index space accepted by GetIPAddress: GetIPAddress(entry, i)
+// is valid for i in [0, size) and returns an error for i >= size. Unlike
+// ValidatePool, it requires the pool to be bounded (Start with End/Subnet, or
+// Subnet only) so that a finite size can be computed.
+func GetPoolSize(entry Pool) (int, error) {
+	if err := ValidatePool(entry); err != nil {
+		return 0, err
+	}
+	if entry.Start == nil && entry.Subnet == nil {
+		return 0, errors.New("either Start or Subnet is required for ipAddress")
+	}
+
+	var startIP, endIP net.IP
+	inclusiveStart := true
+
+	switch {
+	case entry.Start != nil && entry.End != nil:
+		startIP = net.ParseIP(string(*entry.Start))
+		endIP = net.ParseIP(string(*entry.End))
+	case entry.Start != nil && entry.Subnet != nil:
+		_, ipNet, err := net.ParseCIDR(string(*entry.Subnet))
+		if err != nil {
+			return 0, err
+		}
+		startIP = net.ParseIP(string(*entry.Start))
+		endIP = lastIPInSubnet(ipNet)
+	case entry.Start != nil:
+		return 0, errors.New("pool with Start requires End or Subnet to determine size")
+	default:
+		_, ipNet, err := net.ParseCIDR(string(*entry.Subnet))
+		if err != nil {
+			return 0, err
+		}
+		// GetIPAddress with Subnet-only maps index 0 to network+1, so the
+		// network address itself is excluded from the index space.
+		startIP = ipNet.IP
+		endIP = lastIPInSubnet(ipNet)
+		inclusiveStart = false
+	}
+
+	s := new(big.Int).SetBytes(startIP.To16())
+	e := new(big.Int).SetBytes(endIP.To16())
+	diff := new(big.Int).Sub(e, s)
+	if diff.Sign() < 0 {
+		return 0, fmt.Errorf("end IP %s is before start IP %s", endIP, startIP)
+	}
+	if inclusiveStart {
+		diff.Add(diff, big.NewInt(1))
+	}
+	if !diff.IsInt64() || diff.Int64() > math.MaxInt {
+		return 0, errors.New("pool size exceeds int range")
+	}
+	return int(diff.Int64()), nil
+}
+
+// lastIPInSubnet returns the highest address contained in the given CIDR.
+func lastIPInSubnet(n *net.IPNet) net.IP {
+	last := make(net.IP, len(n.IP))
+	for i := range n.IP {
+		last[i] = n.IP[i] | ^n.Mask[i]
+	}
+	return last
 }
 
 // addOffsetToIP computes the value of the IP address with the offset. It is

--- a/api/v1alpha1/utils_test.go
+++ b/api/v1alpha1/utils_test.go
@@ -185,4 +185,182 @@ var _ = Describe("IPPool manager", func() {
 		}),
 	)
 
+	type testCaseGetPoolSize struct {
+		pool         Pool
+		expectError  bool
+		expectedSize int
+	}
+
+	DescribeTable("Test GetPoolSize",
+		func(tc testCaseGetPoolSize) {
+			size, err := GetPoolSize(tc.pool)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(tc.expectedSize))
+			}
+		},
+		Entry("Empty Start and Subnet", testCaseGetPoolSize{
+			pool:        Pool{},
+			expectError: true,
+		}),
+		Entry("Start set, end and subnet unset", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+			},
+			expectError: true,
+		}),
+		Entry("Start and End set, inclusive range", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.20")),
+			},
+			expectedSize: 11,
+		}),
+		Entry("Start and End set, single address", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.10")),
+			},
+			expectedSize: 1,
+		}),
+		Entry("Start and End set, end before start", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.20")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.10")),
+			},
+			expectError: true,
+		}),
+		Entry("Start and Subnet set, subnet bounds the end", testCaseGetPoolSize{
+			pool: Pool{
+				Start:  (*IPAddressStr)(ptr.To("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(ptr.To("192.168.0.0/24")),
+			},
+			expectedSize: 246,
+		}),
+		Entry("Subnet only excludes network address", testCaseGetPoolSize{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("192.168.0.0/24")),
+			},
+			expectedSize: 255,
+		}),
+		Entry("Subnet only with host bits set is normalized", testCaseGetPoolSize{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("192.168.0.10/24")),
+			},
+			expectedSize: 255,
+		}),
+		Entry("Invalid Start IP", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("not-an-ip")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.20")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid End IP", testCaseGetPoolSize{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+				End:   (*IPAddressStr)(ptr.To("not-an-ip")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid Subnet with Start", testCaseGetPoolSize{
+			pool: Pool{
+				Start:  (*IPAddressStr)(ptr.To("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(ptr.To("not-a-cidr")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid Subnet only", testCaseGetPoolSize{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("not-a-cidr")),
+			},
+			expectError: true,
+		}),
+	)
+
+	type testCaseValidatePool struct {
+		pool        Pool
+		expectError bool
+	}
+
+	DescribeTable("Test ValidatePool",
+		func(tc testCaseValidatePool) {
+			err := ValidatePool(tc.pool)
+			if tc.expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// ValidatePool is lenient about presence: empty, Start-only and End-only
+		// pools are valid (the sequential strategy can use an unbounded pool).
+		Entry("Empty pool is valid", testCaseValidatePool{
+			pool: Pool{},
+		}),
+		Entry("Start only is valid", testCaseValidatePool{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+			},
+		}),
+		Entry("End only is valid", testCaseValidatePool{
+			pool: Pool{
+				End: (*IPAddressStr)(ptr.To("192.168.0.20")),
+			},
+		}),
+		Entry("Start and End set", testCaseValidatePool{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.20")),
+			},
+		}),
+		Entry("Start and Subnet set", testCaseValidatePool{
+			pool: Pool{
+				Start:  (*IPAddressStr)(ptr.To("192.168.0.10")),
+				Subnet: (*IPSubnetStr)(ptr.To("192.168.0.0/24")),
+			},
+		}),
+		Entry("Subnet only", testCaseValidatePool{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("192.168.0.0/24")),
+			},
+		}),
+		Entry("End before Start", testCaseValidatePool{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.20")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.10")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid Start IP", testCaseValidatePool{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("not-an-ip")),
+				End:   (*IPAddressStr)(ptr.To("192.168.0.20")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid End IP", testCaseValidatePool{
+			pool: Pool{
+				Start: (*IPAddressStr)(ptr.To("192.168.0.10")),
+				End:   (*IPAddressStr)(ptr.To("not-an-ip")),
+			},
+			expectError: true,
+		}),
+		Entry("Invalid Subnet", testCaseValidatePool{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("not-a-cidr")),
+			},
+			expectError: true,
+		}),
+		// A large IPv6 subnet is a valid pool even though its size exceeds the
+		// int range; GetPoolSize rejects it but ValidatePool must not, since the
+		// sequential strategy can still use it.
+		Entry("Large IPv6 subnet is valid", testCaseValidatePool{
+			pool: Pool{
+				Subnet: (*IPSubnetStr)(ptr.To("2001:db8::/32")),
+			},
+		}),
+	)
+
 })

--- a/config/crd/bases/ipam.metal3.io_ippools.yaml
+++ b/config/crd/bases/ipam.metal3.io_ippools.yaml
@@ -59,6 +59,19 @@ spec:
           spec:
             description: IPPoolSpec defines the desired state of IPPool.
             properties:
+              allocationStrategy:
+                default: sequential
+                description: |-
+                  AllocationStrategy defines how IP addresses are allocated from the pools.
+                  "sequential" (default) allocates the first available IP.
+                  "random" allocates a random available IP.
+                  In both strategies, multiple pools are consumed in declaration order: a
+                  pool is fully exhausted before the next one is used, and the strategy only
+                  changes how an address is selected within a single pool.
+                enum:
+                - sequential
+                - random
+                type: string
               clusterName:
                 description: ClusterName is the name of the Cluster this object belongs
                   to.

--- a/internal/webhooks/v1alpha1/ipaddress_webhook.go
+++ b/internal/webhooks/v1alpha1/ipaddress_webhook.go
@@ -81,7 +81,7 @@ func (webhook *IPAddress) ValidateCreate(_ context.Context, ipAddress *ipamv1.IP
 				"cannot be empty",
 			),
 		)
-	} else if validateIP(ipAddress.Spec.Address) != nil {
+	} else if validateIPAddress(ipAddress.Spec.Address) != nil {
 		allErrs = append(allErrs,
 			field.Invalid(
 				field.NewPath("spec", "address"),
@@ -93,7 +93,7 @@ func (webhook *IPAddress) ValidateCreate(_ context.Context, ipAddress *ipamv1.IP
 
 	// Validate requested IP address if present in annotations (for CAPI claims)
 	if requestedIP, ok := ipAddress.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
-		if validateIP(ipamv1.IPAddressStr(requestedIP)) != nil {
+		if validateIPAddress(ipamv1.IPAddressStr(requestedIP)) != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("metadata", "annotations", "ipAddress"),

--- a/internal/webhooks/v1alpha1/ipclaim_webhook.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook.go
@@ -65,7 +65,7 @@ func (webhook *IPClaim) ValidateCreate(_ context.Context, ipClaim *ipamv1.IPClai
 
 	// Validate requested IP address if present in annotations
 	if requestedIP, ok := ipClaim.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
-		if err := validateIP(ipamv1.IPAddressStr(requestedIP)); err != nil {
+		if err := validateIPAddress(ipamv1.IPAddressStr(requestedIP)); err != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("metadata", "annotations", "ipAddress"),
@@ -121,7 +121,7 @@ func (webhook *IPClaim) ValidateUpdate(_ context.Context, oldIPClaim, newIPClaim
 
 	// Validate requested IP address if present in annotations
 	if requestedIP, ok := newIPClaim.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
-		if err := validateIP(ipamv1.IPAddressStr(requestedIP)); err != nil {
+		if err := validateIPAddress(ipamv1.IPAddressStr(requestedIP)); err != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("metadata", "annotations", "ipAddress"),

--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -16,7 +16,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -31,7 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-func validateIP(s ipamv1.IPAddressStr) error {
+// validateIPAddress validates that the given string is a valid IP address.
+func validateIPAddress(s ipamv1.IPAddressStr) error {
 	if s == "" {
 		return nil
 	}
@@ -57,7 +57,10 @@ type IPPool struct{}
 var _ admission.Defaulter[*ipamv1.IPPool] = &IPPool{}
 var _ admission.Validator[*ipamv1.IPPool] = &IPPool{}
 
-func (webhook *IPPool) Default(_ context.Context, _ *ipamv1.IPPool) error {
+func (webhook *IPPool) Default(_ context.Context, ipPool *ipamv1.IPPool) error {
+	if ipPool.Spec.AllocationStrategy == "" {
+		ipPool.Spec.AllocationStrategy = ipamv1.AllocationStrategySequential
+	}
 	return nil
 }
 
@@ -91,6 +94,27 @@ func (webhook *IPPool) ValidateUpdate(_ context.Context, oldIPPool, newIPPool *i
 				field.NewPath("spec", "NamePrefix"),
 				newIPPool.Spec.NamePrefix,
 				"cannot be modified",
+			),
+		)
+	}
+
+	// Treat an empty strategy as the default (sequential) so legacy objects
+	// stored before this field existed cannot be silently switched, and so
+	// the comparison is symmetric on both sides.
+	oldStrategy := oldIPPool.Spec.AllocationStrategy
+	if oldStrategy == "" {
+		oldStrategy = ipamv1.AllocationStrategySequential
+	}
+	newStrategy := newIPPool.Spec.AllocationStrategy
+	if newStrategy == "" {
+		newStrategy = ipamv1.AllocationStrategySequential
+	}
+	if newStrategy != oldStrategy {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "allocationStrategy"),
+				newIPPool.Spec.AllocationStrategy,
+				"cannot be modified after creation",
 			),
 		)
 	}
@@ -194,13 +218,14 @@ func (webhook *IPPool) isAddressInBonds(newPool *ipamv1.IPPool, address ipamv1.I
 	return false
 }
 
-// validatePoolRanges validates that start <= end for each pool and validates all IP addresses.
+// validatePoolRanges validates that start <= end for each pool and validates
+// the IP address fields defined in the IPPool spec.
 func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// Validate gateway IP if present
+	// Validate spec-level gateway IP
 	if pool.Spec.Gateway != nil {
-		if err := validateIP(*pool.Spec.Gateway); err != nil {
+		if err := validateIPAddress(*pool.Spec.Gateway); err != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec", "gateway"),
@@ -211,9 +236,9 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 		}
 	}
 
-	// Validate DNS server IPs
+	// Validate spec-level DNS server IPs
 	for i, dnsServer := range pool.Spec.DNSServers {
-		if err := validateIP(dnsServer); err != nil {
+		if err := validateIPAddress(dnsServer); err != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec", "dnsServers").Index(i),
@@ -226,7 +251,7 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 
 	// Validate preAllocations IPs
 	for name, ipAddr := range pool.Spec.PreAllocations {
-		if err := validateIP(ipAddr); err != nil {
+		if err := validateIPAddress(ipAddr); err != nil {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec", "preAllocations", name),
@@ -237,87 +262,39 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 		}
 	}
 
-	for i, pool := range pool.Spec.Pools {
-		// Validate Start IP
-		if pool.Start != nil {
-			if err := validateIP(*pool.Start); err != nil {
-				allErrs = append(allErrs,
-					field.Invalid(
-						field.NewPath("spec", "pools").Index(i).Child("start"),
-						*pool.Start,
-						"is not a valid IP address",
-					),
-				)
+	// Validate each pool entry
+	randomStrategy := pool.Spec.AllocationStrategy == ipamv1.AllocationStrategyRandom
+	for i, p := range pool.Spec.Pools {
+		poolPath := field.NewPath("spec", "pools").Index(i)
+		errCountBefore := len(allErrs)
+
+		// Address-range fields (Start/End/Subnet format and start <= end) are
+		// validated by the shared api helper, so the logic is not duplicated
+		// between the webhook and GetPoolSize.
+		if err := ipamv1.ValidatePool(p); err != nil {
+			allErrs = append(allErrs, field.Invalid(poolPath, "", err.Error()))
+		}
+		if p.Gateway != nil {
+			if err := validateIPAddress(*p.Gateway); err != nil {
+				allErrs = append(allErrs, field.Invalid(poolPath.Child("gateway"), *p.Gateway, "is not a valid IP address"))
+			}
+		}
+		for j, dnsServer := range p.DNSServers {
+			if err := validateIPAddress(dnsServer); err != nil {
+				allErrs = append(allErrs, field.Invalid(poolPath.Child("dnsServers").Index(j), dnsServer, "is not a valid IP address"))
 			}
 		}
 
-		// Validate End IP
-		if pool.End != nil {
-			if err := validateIP(*pool.End); err != nil {
-				allErrs = append(allErrs,
-					field.Invalid(
-						field.NewPath("spec", "pools").Index(i).Child("end"),
-						*pool.End,
-						"is not a valid IP address",
-					),
-				)
-			}
-		}
-
-		// Validate Subnet CIDR
-		if pool.Subnet != nil {
-			if _, _, err := net.ParseCIDR(string(*pool.Subnet)); err != nil {
-				allErrs = append(allErrs,
-					field.Invalid(
-						field.NewPath("spec", "pools").Index(i).Child("subnet"),
-						*pool.Subnet,
-						"is not a valid CIDR",
-					),
-				)
-			}
-		}
-
-		// Validate pool-specific gateway IP
-		if pool.Gateway != nil {
-			if err := validateIP(*pool.Gateway); err != nil {
-				allErrs = append(allErrs,
-					field.Invalid(
-						field.NewPath("spec", "pools").Index(i).Child("gateway"),
-						*pool.Gateway,
-						"is not a valid IP address",
-					),
-				)
-			}
-		}
-
-		// Validate pool-specific DNS server IPs
-		for j, dnsServer := range pool.DNSServers {
-			if err := validateIP(dnsServer); err != nil {
-				allErrs = append(allErrs,
-					field.Invalid(
-						field.NewPath("spec", "pools").Index(i).Child("dnsServers").Index(j),
-						dnsServer,
-						"is not a valid IP address",
-					),
-				)
-			}
-		}
-		// Validate start <= end if both are present and valid
-		if pool.Start != nil && pool.End != nil {
-			startIP := net.ParseIP(string(*pool.Start))
-			endIP := net.ParseIP(string(*pool.End))
-
-			// Only compare if both IPs parsed successfully
-			if startIP != nil && endIP != nil {
-				if bytes.Compare(startIP, endIP) > 0 {
-					allErrs = append(allErrs,
-						field.Invalid(
-							field.NewPath("spec", "pools").Index(i),
-							fmt.Sprintf("start: %s, end: %s", *pool.Start, *pool.End),
-							"start address must be less than or equal to end address",
-						),
-					)
-				}
+		// The random allocation strategy needs a bounded, index-addressable pool
+		// so it can pick a random offset within the pool size. Pools that are
+		// unbounded (Start without End/Subnet) or too large to index (e.g. large
+		// IPv6 subnets) work with the sequential strategy but would otherwise fail
+		// silently at allocation time as "Exhausted IP Pools". Reject them here so
+		// the failure is explicit at apply time. Skip pools that already have field
+		// errors to avoid duplicate, redundant errors.
+		if randomStrategy && errCountBefore == len(allErrs) {
+			if _, err := ipamv1.GetPoolSize(p); err != nil {
+				allErrs = append(allErrs, field.Invalid(poolPath, "", fmt.Sprintf("cannot be used with allocationStrategy %q: %v", ipamv1.AllocationStrategyRandom, err)))
 			}
 		}
 	}

--- a/internal/webhooks/v1alpha1/ippool_webhook_test.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook_test.go
@@ -38,8 +38,25 @@ func TestIPPoolDefault(t *testing.T) {
 	}
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
-	g.Expect(c.Spec).To(Equal(ipamv1.IPPoolSpec{}))
+	g.Expect(c.Spec.AllocationStrategy).To(Equal(ipamv1.AllocationStrategySequential))
 	g.Expect(c.Status).To(Equal(ipamv1.IPPoolStatus{}))
+}
+
+func TestIPPoolDefaultPreservesExistingStrategy(t *testing.T) {
+	g := NewWithT(t)
+	webhook := &IPPool{}
+
+	c := &ipamv1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: ipamv1.IPPoolSpec{
+			AllocationStrategy: ipamv1.AllocationStrategyRandom,
+		},
+	}
+	g.Expect(webhook.Default(ctx, c)).To(Succeed())
+
+	g.Expect(c.Spec.AllocationStrategy).To(Equal(ipamv1.AllocationStrategyRandom))
 }
 
 func TestIPPoolValidation(t *testing.T) {
@@ -51,6 +68,8 @@ func TestIPPoolValidation(t *testing.T) {
 	malformedIP := ipamv1.IPAddressStr("not-an-ip")
 	invalidIPFormat := ipamv1.IPAddressStr("256.256.256.256")
 	malformedCIDR := ipamv1.IPSubnetStr("not-a-cidr")
+	validSubnet := ipamv1.IPSubnetStr("192.168.0.0/24")
+	largeV6Subnet := ipamv1.IPSubnetStr("2001:db8::/32")
 	validGateway := ipamv1.IPAddressStr("192.168.0.1")
 	malformedGateway := ipamv1.IPAddressStr("invalid-gateway")
 
@@ -288,6 +307,112 @@ func TestIPPoolValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "should succeed with random strategy when pool is bounded by start and end",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr, End: &endAddr},
+					},
+				},
+			},
+		},
+		{
+			name:      "should succeed with random strategy when pool is bounded by subnet only",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Subnet: &validSubnet},
+					},
+				},
+			},
+		},
+		{
+			name:      "should succeed with random strategy when pool is bounded by start and subnet",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr, Subnet: &validSubnet},
+					},
+				},
+			},
+		},
+		{
+			name:      "should fail with random strategy when pool is unbounded (start only)",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr},
+					},
+				},
+			},
+		},
+		{
+			name:      "should fail with random strategy when one pool is unbounded",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr, End: &endAddr},
+						{Start: &startAddr},
+					},
+				},
+			},
+		},
+		{
+			name:      "should fail with random strategy when pool is too large to index",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Pools: []ipamv1.Pool{
+						{Subnet: &largeV6Subnet},
+					},
+				},
+			},
+		},
+		{
+			name:      "should succeed with sequential strategy when pool is unbounded (start only)",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					AllocationStrategy: ipamv1.AllocationStrategySequential,
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -452,6 +577,26 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 				Allocations: map[string]ipamv1.IPAddressStr{
 					"inuse": ipamv1.IPAddressStr("192.168.0.3"),
 				},
+			},
+		},
+		{
+			name:      "should fail when allocationStrategy changes",
+			expectErr: true,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				AllocationStrategy: ipamv1.AllocationStrategyRandom,
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				AllocationStrategy: ipamv1.AllocationStrategySequential,
+			},
+		},
+		{
+			name:      "should succeed when allocationStrategy stays the same",
+			expectErr: false,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				AllocationStrategy: ipamv1.AllocationStrategyRandom,
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				AllocationStrategy: ipamv1.AllocationStrategyRandom,
 			},
 		},
 		{

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"strings"
@@ -453,38 +454,37 @@ func (m *IPPoolManager) allocateAddress(addressClaim *ipamv1.IPClaim,
 		if ipAllocated {
 			break
 		}
-		index := 0
-		for !ipAllocated {
-			allocatedAddress, err = ipamv1.GetIPAddress(pool, index)
-			if err != nil {
-				break
-			}
-			index++
-			// Check if requestedIP is present and matches the current address
-			if requestedIP != "" && !m.ipEqual(allocatedAddress, requestedIP) {
-				continue
-			}
-			if requestedIP != "" && m.ipEqual(allocatedAddress, requestedIP) {
-				isRequestedIPAllocated = true
-			}
-			// We have a pre-allocated ip, we just need to ensure that it matches the current address
-			// if it does not, continue and try the next address
-			if ipPreAllocated && !m.ipEqual(allocatedAddress, preAllocatedAddress) {
-				continue
-			}
-			// Here the two addresses match, so we continue with that one
-			if ipPreAllocated {
-				ipAllocated = true
-			}
-			// If we have a preallocated address, this is useless, otherwise, check if the
-			// ip is free
-			if _, ok := addresses[allocatedAddress]; !ok && allocatedAddress != "" {
-				ipAllocated = true
-			}
-			if !ipAllocated {
-				continue
-			}
 
+		// PreAllocations and requestedIP always use sequential scan
+		if ipPreAllocated || requestedIP != "" {
+			index := 0
+			for !ipAllocated {
+				allocatedAddress, err = ipamv1.GetIPAddress(pool, index)
+				if err != nil {
+					break
+				}
+				index++
+				if requestedIP != "" && !m.ipEqual(allocatedAddress, requestedIP) {
+					continue
+				}
+				if requestedIP != "" && m.ipEqual(allocatedAddress, requestedIP) {
+					isRequestedIPAllocated = true
+				}
+				if ipPreAllocated && !m.ipEqual(allocatedAddress, preAllocatedAddress) {
+					continue
+				}
+				if ipPreAllocated {
+					ipAllocated = true
+				}
+				if _, ok := addresses[allocatedAddress]; !ok && allocatedAddress != "" {
+					ipAllocated = true
+				}
+			}
+		} else {
+			allocatedAddress, ipAllocated = m.selectIPFromPool(pool, addresses)
+		}
+
+		if ipAllocated {
 			if pool.Prefix != 0 {
 				prefix = pool.Prefix
 			}
@@ -552,38 +552,37 @@ func (m *IPPoolManager) capiAllocateAddress(addressClaim *capipamv1.IPAddressCla
 		if ipAllocated {
 			break
 		}
-		index := 0
-		for !ipAllocated {
-			allocatedAddress, err = ipamv1.GetIPAddress(pool, index)
-			if err != nil {
-				break
-			}
-			index++
-			// Check if requestedIP is present and matches the current address
-			if requestedIP != "" && !m.ipEqual(allocatedAddress, requestedIP) {
-				continue
-			}
-			if requestedIP != "" && m.ipEqual(allocatedAddress, requestedIP) {
-				isRequestedIPAllocated = true
-			}
-			// We have a pre-allocated ip, we just need to ensure that it matches the current address
-			// if it does not, continue and try the next address
-			if ipPreAllocated && !m.ipEqual(allocatedAddress, preAllocatedAddress) {
-				continue
-			}
-			// Here the two addresses match, so we continue with that one
-			if ipPreAllocated {
-				ipAllocated = true
-			}
-			// If we have a preallocated address, this is useless, otherwise, check if the
-			// ip is free
-			if _, ok := addresses[allocatedAddress]; !ok && allocatedAddress != "" {
-				ipAllocated = true
-			}
-			if !ipAllocated {
-				continue
-			}
 
+		// PreAllocations and requestedIP always use sequential scan
+		if ipPreAllocated || requestedIP != "" {
+			index := 0
+			for !ipAllocated {
+				allocatedAddress, err = ipamv1.GetIPAddress(pool, index)
+				if err != nil {
+					break
+				}
+				index++
+				if requestedIP != "" && !m.ipEqual(allocatedAddress, requestedIP) {
+					continue
+				}
+				if requestedIP != "" && m.ipEqual(allocatedAddress, requestedIP) {
+					isRequestedIPAllocated = true
+				}
+				if ipPreAllocated && !m.ipEqual(allocatedAddress, preAllocatedAddress) {
+					continue
+				}
+				if ipPreAllocated {
+					ipAllocated = true
+				}
+				if _, ok := addresses[allocatedAddress]; !ok && allocatedAddress != "" {
+					ipAllocated = true
+				}
+			}
+		} else {
+			allocatedAddress, ipAllocated = m.selectIPFromPool(pool, addresses)
+		}
+
+		if ipAllocated {
 			if pool.Prefix != 0 {
 				prefix = pool.Prefix
 			}
@@ -983,6 +982,47 @@ func (m *IPPoolManager) capiDeleteAddress(ctx context.Context,
 	}
 	m.updateStatusTimestamp()
 	return addresses, nil
+}
+
+// selectIPFromPool picks an available IP from the given pool based on the allocation strategy.
+// Returns the selected IP and true, or empty string and false if no IP is available.
+func (m *IPPoolManager) selectIPFromPool(pool ipamv1.Pool, addresses map[ipamv1.IPAddressStr]string) (ipamv1.IPAddressStr, bool) {
+	if m.IPPool.Spec.AllocationStrategy == ipamv1.AllocationStrategyRandom {
+		// Pick a random offset in the pool and scan forward, wrapping around
+		// at the end. This walks each index at most once and returns the first
+		// free IP encountered, giving O(1) memory and removing the asymmetry
+		// of a fixed-size candidate window.
+		size, err := ipamv1.GetPoolSize(pool)
+		if err != nil || size <= 0 {
+			return "", false
+		}
+		start := rand.IntN(size) //nolint:gosec // cryptographic randomness not needed for IP allocation
+		for i := range size {
+			index := (start + i) % size
+			candidate, err := ipamv1.GetIPAddress(pool, index)
+			if err != nil {
+				continue
+			}
+			if _, ok := addresses[candidate]; !ok && candidate != "" {
+				return candidate, true
+			}
+		}
+		return "", false
+	}
+
+	// Sequential allocation (default)
+	index := 0
+	for {
+		candidate, err := ipamv1.GetIPAddress(pool, index)
+		if err != nil {
+			break
+		}
+		index++
+		if _, ok := addresses[candidate]; !ok && candidate != "" {
+			return candidate, true
+		}
+	}
+	return "", false
 }
 
 // formatAddressName renders the name of the IPAddress objects.

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package ipam
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"net"
 	"reflect"
 
 	"github.com/go-logr/logr"
@@ -705,7 +708,11 @@ var _ = Describe("IPPool manager", func() {
 			}
 			Expect(nbAllocations).To(Equal(tc.expectedNbAllocations))
 			Expect(tc.ipPool.Status.LastUpdated).ToNot(BeNil())
-			Expect(tc.ipPool.Status.Allocations).To(Equal(tc.expectedAllocations))
+			if tc.expectedAllocations != nil {
+				Expect(tc.ipPool.Status.Allocations).To(Equal(tc.expectedAllocations))
+			} else {
+				Expect(tc.ipPool.Status.Allocations).To(HaveLen(tc.expectedNbAllocations))
+			}
 
 			// get list of IPAddress objects
 			addressObjects := ipamv1.IPClaimList{}
@@ -1499,6 +1506,131 @@ var _ = Describe("IPPool manager", func() {
 				"inUseClaim": ipamv1.IPAddressStr("192.168.1.11"),
 			},
 			expectedNbAllocations: 1,
+		}),
+		Entry("Random strategy: new IPClaim gets IP within pool range", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+					NamePrefix:         "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipClaims: []*ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+				},
+			},
+			expectedNbAllocations: 1,
+		}),
+		Entry("Random strategy: new CAPI IPAddressClaim gets IP within pool range", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+					NamePrefix:         "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cabc",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *capiPoolRef,
+					},
+				},
+			},
+			expectedNbAllocations: 1,
+		}),
+		Entry("Random strategy: multiple claims get unique IPs", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+					NamePrefix:         "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipClaims: []*ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim1",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim2",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "caclaim1",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *capiPoolRef,
+					},
+				},
+			},
+			expectedNbAllocations: 3,
 		}),
 	)
 
@@ -3078,5 +3210,341 @@ var _ = Describe("IPPool manager", func() {
 			},
 		}),
 	)
+
+	// Helper to check if an IP is within a range.
+	// Uses lexicographic byte comparison so ranges that cross octet
+	// boundaries (e.g., 192.168.0.10 - 192.168.2.20) are handled correctly.
+	isIPInRange := func(ipStr ipamv1.IPAddressStr, startStr, endStr string) bool {
+		ip := net.ParseIP(string(ipStr))
+		start := net.ParseIP(startStr)
+		end := net.ParseIP(endStr)
+		if ip == nil || start == nil || end == nil {
+			return false
+		}
+		ip = ip.To16()
+		start = start.To16()
+		end = end.To16()
+		return bytes.Compare(ip, start) >= 0 && bytes.Compare(ip, end) <= 0
+	}
+
+	Context("isIPInRange helper", func() {
+		It("should handle ranges that cross byte boundaries", func() {
+			// 192.168.1.5 is inside [192.168.0.10, 192.168.2.20] but a naive
+			// per-byte comparison would reject it because byte 3 (5) is less
+			// than the start byte 3 (10).
+			Expect(isIPInRange("192.168.1.5", "192.168.0.10", "192.168.2.20")).To(BeTrue(),
+				"192.168.1.5 should be within 192.168.0.10-192.168.2.20")
+		})
+		It("should include the boundary IPs", func() {
+			Expect(isIPInRange("192.168.0.10", "192.168.0.10", "192.168.0.20")).To(BeTrue())
+			Expect(isIPInRange("192.168.0.20", "192.168.0.10", "192.168.0.20")).To(BeTrue())
+		})
+		It("should reject IPs outside the range", func() {
+			Expect(isIPInRange("192.168.0.9", "192.168.0.10", "192.168.0.20")).To(BeFalse())
+			Expect(isIPInRange("192.168.0.21", "192.168.0.10", "192.168.0.20")).To(BeFalse())
+		})
+	})
+
+	Context("Random allocation strategy", func() {
+		It("should allocate an IP within pool range", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, prefix, gateway, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isIPInRange(allocatedAddress, "192.168.0.10", "192.168.0.20")).To(BeTrue(),
+				fmt.Sprintf("allocated IP %s should be in range 192.168.0.10-192.168.0.20", allocatedAddress))
+			Expect(prefix).To(Equal(24))
+			Expect(*gateway).To(Equal(ipamv1.IPAddressStr("192.168.0.1")))
+		})
+
+		It("should allocate the last remaining IP in a nearly full pool", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.14")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			}
+			// All IPs except .12 are taken
+			addresses := map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.10"): "a",
+				ipamv1.IPAddressStr("192.168.0.11"): "b",
+				ipamv1.IPAddressStr("192.168.0.13"): "d",
+				ipamv1.IPAddressStr("192.168.0.14"): "e",
+			}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocatedAddress).To(Equal(ipamv1.IPAddressStr("192.168.0.12")))
+		})
+
+		It("should return error when pool is exhausted", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.12")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{
+				ipamv1.IPAddressStr("192.168.0.10"): "a",
+				ipamv1.IPAddressStr("192.168.0.11"): "b",
+				ipamv1.IPAddressStr("192.168.0.12"): "c",
+			}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, _, err = ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should respect PreAllocations even with random strategy", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"TestRef": ipamv1.IPAddressStr("192.168.0.15"),
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocatedAddress).To(Equal(ipamv1.IPAddressStr("192.168.0.15")))
+		})
+
+		It("should respect requestedIP annotation even with random strategy", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "192.168.0.16",
+					},
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocatedAddress).To(Equal(ipamv1.IPAddressStr("192.168.0.16")))
+		})
+
+		It("should not allocate duplicate IPs with random strategy", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+
+			addresses := map[ipamv1.IPAddressStr]string{}
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Allocate all 11 IPs and verify no duplicates
+			for i := range 11 {
+				ipClaim := &ipamv1.IPClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("TestRef-%d", i),
+					},
+				}
+				allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(addresses).NotTo(HaveKey(allocatedAddress), fmt.Sprintf("duplicate IP allocated: %s", allocatedAddress))
+				addresses[allocatedAddress] = ipClaim.Name
+			}
+			Expect(addresses).To(HaveLen(11))
+		})
+
+		It("should select the only available IP when others are already allocated", func() {
+			// Pool of 3 IPs (.10, .11, .12) with .10 and .12 already allocated.
+			// Random selection must deterministically return the only remaining IP (.11),
+			// which proves the available-set computation works regardless of randomness.
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.12")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{
+				"192.168.0.10": "claim-a",
+				"192.168.0.12": "claim-c",
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-b"},
+			}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allocatedAddress).To(Equal(ipamv1.IPAddressStr("192.168.0.11")))
+		})
+
+		It("should error with exhausted IP pools when no IP is available", func() {
+			// All IPs in the pool are already allocated; the random branch must
+			// surface "exhausted IP pools" rather than returning a duplicate.
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{
+				"192.168.0.10": "claim-a",
+				"192.168.0.11": "claim-b",
+			}
+			ipClaim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-c"},
+			}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, _, _, _, err := ipPoolMgr.allocateAddress(ipClaim, addresses)
+			Expect(err).To(MatchError("exhausted IP pools"))
+			Expect(allocatedAddress).To(Equal(ipamv1.IPAddressStr("")))
+			Expect(ipClaim.Status.ErrorMessage).To(Equal(ptr.To("Exhausted IP Pools")))
+		})
+
+		It("capi: should allocate an IP within pool range with random strategy", func() {
+			ipPool := &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.10")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					AllocationStrategy: ipamv1.AllocationStrategyRandom,
+					Prefix:             24,
+					Gateway:            (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			}
+			ipAddressClaim := &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+				},
+				Spec: capipamv1.IPAddressClaimSpec{
+					PoolRef: capipamv1.IPPoolReference{
+						Name: "abc",
+					},
+				},
+			}
+			addresses := map[ipamv1.IPAddressStr]string{}
+
+			ipPoolMgr, err := NewIPPoolManager(nil, ipPool, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			allocatedAddress, prefix, gateway, err := ipPoolMgr.capiAllocateAddress(ipAddressClaim, addresses)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isIPInRange(allocatedAddress, "192.168.0.10", "192.168.0.20")).To(BeTrue(),
+				fmt.Sprintf("allocated IP %s should be in range 192.168.0.10-192.168.0.20", allocatedAddress))
+			Expect(prefix).To(Equal(int32(24)))
+			Expect(*gateway).To(Equal(ipamv1.IPAddressStr("192.168.0.1")))
+		})
+	})
 
 })


### PR DESCRIPTION
Introduce an AllocationStrategy field to IPPoolSpec that allows choosing between "sequential" (default) and "random" allocation.

When set to "random", a random offset within the pool is chosen and the pool is scanned forward (wrapping around at the end) until the first available IP is found. This walks each index at most once, giving O(1) memory usage.

- Add AllocationStrategy type with "sequential"/"random" enum values
- Extract selectIPFromPool() helper to share logic between allocateAddress() and  capiAllocateAddress()
- Add webhook defaulting (sequential) and immutability validation
- PreAllocations and requestedIP annotation bypass random strategy

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
Currently, IP addresses are always allocated sequentially (first available IP from the pool). This PR introduces an
 allocationStrategy field to IPPoolSpec that allows choosing between sequential (default, existing behavior) and   
random allocation.

When set to random, a random offset within the pool is chosen and the pool is scanned forward (wrapping around at
the end) until the first available IP is found. Each index is visited at most once, so allocation uses O(1) memory.

Key changes:
- Add AllocationStrategy type with sequential/random enum values to IPPoolSpec
- Extract selectIPFromPool() helper to share allocation logic between allocateAddress() and capiAllocateAddress()
- Add webhook defaulting (sequential) and immutability validation
- PreAllocations and ipAddress annotation bypass random strategy and always use sequential scan

                                                                                                                     
```yaml
apiVersion: ipam.metal3.io/v1alpha1                                                                                
kind: IPPool                                                                                                       
spec:                                                                                                              
  allocationStrategy: random
  pools:                                                                                                           
    - start: 192.168.0.10                                 
      end: 192.168.0.50  
      prefix: 24                                                                                                   
      gateway: 192.168.0.1
```
<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
