### PR TITLE
🐛 Simplify ownerRefs for IPAddresses

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -681,24 +681,24 @@ func (m *IPPoolManager) createAddress(ctx context.Context,
 
 	m.Log.Info("Address allocated", "Claim", addressClaim.Name, "address", allocatedAddress)
 
-	ownerRefs := addressClaim.OwnerReferences
-	ownerRefs = append(ownerRefs,
-		metav1.OwnerReference{
+	// Construct ownerRefs for the IPClaim and the IPPool.
+	ownerRefs := []metav1.OwnerReference{
+		{
 			APIVersion: m.IPPool.APIVersion,
 			Kind:       m.IPPool.Kind,
 			Name:       m.IPPool.Name,
 			UID:        m.IPPool.UID,
 		},
-		metav1.OwnerReference{
+		{
 			APIVersion: addressClaim.APIVersion,
 			Kind:       addressClaim.Kind,
 			Name:       addressClaim.Name,
 			UID:        addressClaim.UID,
 		},
-	)
+	}
 
-	// Create the IPAddress object, with an Owner ref to the IPClaim,
-	// the IPPool, and the IPClaims owners. Also add a finalizer.
+	// Create the IPAddress object, with an Owner ref to the IPClaim and
+	// the IPPool. Also add a finalizer.
 	addressObject := &ipamv1.IPAddress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "IPAddress",
@@ -788,24 +788,24 @@ func (m *IPPoolManager) capiCreateAddress(ctx context.Context,
 
 	m.Log.Info("Address allocated", "Claim", addressClaim.Name, "address", allocatedAddress)
 
-	ownerRefs := addressClaim.OwnerReferences
-	ownerRefs = append(ownerRefs,
-		metav1.OwnerReference{
+	// Construct ownerRefs for the IPAddressClaim and the IPPool.
+	ownerRefs := []metav1.OwnerReference{
+		{
 			APIVersion: m.IPPool.APIVersion,
 			Kind:       m.IPPool.Kind,
 			Name:       m.IPPool.Name,
 			UID:        m.IPPool.UID,
 		},
-		metav1.OwnerReference{
+		{
 			APIVersion: addressClaim.APIVersion,
 			Kind:       addressClaim.Kind,
 			Name:       addressClaim.Name,
 			UID:        addressClaim.UID,
 		},
-	)
+	}
 
-	// Create the IPAddress object, with an Owner ref to the IPAddressClaim,
-	// the IPPool, and the IPAddressClaim owners. Also add a finalizer.
+	// Create the IPAddress object, with an Owner ref to the IPAddressClaim and
+	// the IPPool. Also add a finalizer.
 	addressObject := &capipamv1beta1.IPAddress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "IPAddress",


### PR DESCRIPTION
Manual backport of #1371 

**What this PR does / why we need it**:

Explicitly set the references we want, instead of appending to IPClaim owners. The ownership chain anyway connects us to the owners of the IPClaim in the end.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
