### PR TITLE
📖Update compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more information about this controller and related repositories, see
 | v1alpha1 (v1.10.X) | v1beta1 (v1.10.X) | v1beta1 (v1.10.X)   | v1.10.X      |
 | v1alpha1 (v1.11.X) | v1beta1 (v1.11.X) | v1beta1 (v1.11.X)   | v1.11.X      |
 | v1alpha1 (v1.12.X) | v1beta1 (v1.12.X) | v1beta2 (v1.12.X)   | v1.12.X      |
+| v1alpha1 (v1.13.X) | v1beta2 (v1.13.X) | v1beta2 (v1.13.X)   | v1.13.X      |
 
 ## Development Environment
 


### PR DESCRIPTION
It was removed in previous revert commit. So we are adding it back.