### PR TITLE
:seedling: Harden binary downloads in 3 scripts

### DIFF
--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -14,45 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# download an url and verify the downloaded object has the same sha as
-# supplied in the function call
+# Download golangci-lint and verify checksum from official checksums.txt
 
-set -eux
+set -eux -o pipefail
 
-CAPM3_DIR="$(dirname "$(readlink -f "$0")")/.."
-
-wget_and_verify()
-{
-    local url="${1:?url missing}"
-    local sha256="${2:?sha256 missing}"
-    local target="${3:?target missing}"
-    local checksum
-
-    declare -a args=(
-        --no-verbose
-        -O "${target}"
-        "${url}"
-    )
-
-    wget "${args[@]}"
-
-    checksum="$(sha256sum "${target}" | awk '{print $1;}')"
-    if [[ "${checksum}" != "${sha256}" ]]; then
-        if [[ "${INSECURE_SKIP_DOWNLOAD_VERIFICATION:-}" == "true" ]]; then
-            echo >&2 "warning: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
-        else
-            echo >&2 "fatal: ${url} binary checksum '${checksum}' differs from expected checksum '${sha256}'"
-            return 1
-        fi
-    fi
-
-    return 0
-}
+IPAM_DIR="$(cd "$(dirname "$0")/.." && pwd -P)"
 
 download_and_install_golangci_lint()
 {
     local tmp_dir
     local bin_dir="${1:?Binary path missing}"
+
+    if ! command -v sha256sum &>/dev/null; then
+        echo "ERROR: sha256sum not found. On macOS, install coreutils: brew install coreutils" >&2
+        exit 1
+    fi
 
     tmp_dir="$(mktemp -d)"
     pushd "${tmp_dir}" || return 1
@@ -61,20 +37,51 @@ download_and_install_golangci_lint()
     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')"
     GOLANGCI_LINT="golangci-lint"
     GOLANGCI_VERSION="2.10.1"
-    case "${KERNEL_OS}-${ARCH}" in
-        darwin-arm64) GOLANGCI_SHA256="03bfadf67e52b441b7ec21305e501c717df93c959836d66c7f97312654acb297" ;;
-        linux-amd64) GOLANGCI_SHA256="dfa775874cf0561b404a02a8f4481fc69b28091da95aa697259820d429b09c99" ;;
-      *)
-        echo >&2 "error:${KERNEL_OS}-${ARCH} not supported. Please obtain the binary and calculate sha256 manually."
-        exit 1
-        ;;
-    esac
-    GOLANGCI_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}.tar.gz"
-    wget_and_verify "${GOLANGCI_URL}" "${GOLANGCI_SHA256}" "${GOLANGCI_LINT}".tar.gz
-    tar zxvf "${GOLANGCI_LINT}".tar.gz
-    rm -f "${GOLANGCI_LINT}".tar.gz
-    mkdir -p "${CAPM3_DIR}/${bin_dir}"
-    mv "${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}/${GOLANGCI_LINT}" "${CAPM3_DIR}/${bin_dir}/"
+
+    # Download checksums file from release
+    CHECKSUMS_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION}-checksums.txt"
+    CHECKSUMS_FILE="checksums.txt"
+    BINARY_FILE="${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}.tar.gz"
+    URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_VERSION}/${BINARY_FILE}"
+
+    # Download checksums file
+    curl --proto '=https' --tlsv1.3 -sSfL \
+        --retry 3 --retry-delay 5 --max-time 120 \
+        -o "${CHECKSUMS_FILE}" "${CHECKSUMS_URL}"
+
+    # Extract the checksum for this platform
+    GOLANGCI_SHA256="$(grep -F -- "${BINARY_FILE}" "${CHECKSUMS_FILE}" | awk '{print $1;}')" || true
+    if [[ -z "${GOLANGCI_SHA256}" ]]; then
+        echo >&2 "fatal: could not find checksum for ${BINARY_FILE} in ${CHECKSUMS_URL}"
+        rm -f "${CHECKSUMS_FILE}"
+        popd || true
+        rm -rf "${tmp_dir}"
+        return 1
+    fi
+
+    # Download binary with security flags
+    curl --proto '=https' --tlsv1.3 -sSfL \
+        --retry 3 --retry-delay 5 --max-time 120 \
+        -o "${BINARY_FILE}" "${URL}"
+
+    # Verify checksum before extraction
+    checksum="$(sha256sum "${BINARY_FILE}" | awk '{print $1;}')" || true
+    if [[ "${checksum}" != "${GOLANGCI_SHA256}" ]]; then
+        echo >&2 "fatal: ${URL} checksum '${checksum}' differs from expected checksum '${GOLANGCI_SHA256}'"
+        popd || true
+        rm -rf "${tmp_dir}"
+        return 1
+    fi
+
+    tar zxvf "${BINARY_FILE}"
+    rm -f "${BINARY_FILE}"
+    mkdir -p "${IPAM_DIR}/${bin_dir}"
+    mv "${GOLANGCI_LINT}-${GOLANGCI_VERSION}-${KERNEL_OS}-${ARCH}/${GOLANGCI_LINT}" "${IPAM_DIR}/${bin_dir}/"
+    chmod 0755 "${IPAM_DIR}/${bin_dir}/${GOLANGCI_LINT}"
+
+    # Clean up temp directory and checksums file
+    popd || true
+    rm -rf "${tmp_dir}"
 }
 
 download_and_install_golangci_lint "$1"

--- a/hack/tools/install_kubebuilder.sh
+++ b/hack/tools/install_kubebuilder.sh
@@ -1,17 +1,54 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 [[ -f bin/kubebuilder ]] && exit 0
 
-version=2.2.0
-arch=amd64
+if ! command -v sha256sum &>/dev/null; then
+    echo "ERROR: sha256sum not found. On macOS, install coreutils: brew install coreutils" >&2
+    exit 1
+fi
+
+version=4.14.0
+arch=$(go env GOARCH)
+os=$(go env GOOS)
 
 mkdir -p ./bin
-curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
 
-tar -zxvf "kubebuilder_${version}_linux_${arch}.tar.gz"
-mv "kubebuilder_${version}_linux_${arch}/bin/"* bin
+CHECKSUMS_URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/checksums.txt"
+CHECKSUMS_FILE="checksums.txt"
+BINARY_FILE="kubebuilder_${os}_${arch}"
+URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/${BINARY_FILE}"
 
-rm "kubebuilder_${version}_linux_${arch}.tar.gz"
-rm -r "kubebuilder_${version}_linux_${arch}"
+# Download checksums file
+curl --proto '=https' --tlsv1.3 -sSfL \
+    --retry 3 --retry-delay 5 --max-time 120 \
+    -o "${CHECKSUMS_FILE}" "${CHECKSUMS_URL}"
+
+# Extract the checksum for this platform
+# Kubebuilder publishes bare binaries, so we match exactly on the filename
+KUBEBUILDER_SHA256="$(grep "kubebuilder_${os}_${arch}$" "${CHECKSUMS_FILE}" | awk '{print $1;}')"
+if [[ -z "${KUBEBUILDER_SHA256}" ]]; then
+    echo >&2 "fatal: could not find checksum for ${BINARY_FILE} in ${CHECKSUMS_URL}"
+    rm -f "${CHECKSUMS_FILE}"
+    exit 1
+fi
+
+# Download binary with security flags
+curl --proto '=https' --tlsv1.3 -sSfL \
+    --retry 3 --retry-delay 5 --max-time 120 \
+    -o "${BINARY_FILE}" "${URL}"
+
+# Verify checksum before using
+checksum="$(sha256sum "${BINARY_FILE}" | awk '{print $1;}')"
+if [[ "${checksum}" != "${KUBEBUILDER_SHA256}" ]]; then
+    echo >&2 "fatal: ${URL} checksum '${checksum}' differs from expected '${KUBEBUILDER_SHA256}'"
+    rm -f "${BINARY_FILE}" "${CHECKSUMS_FILE}"
+    exit 1
+fi
+
+# Install binary
+mv "${BINARY_FILE}" ./bin/kubebuilder
+chmod 0755 ./bin/kubebuilder
+
+rm -f "${CHECKSUMS_FILE}"

--- a/hack/tools/install_kustomize.sh
+++ b/hack/tools/install_kustomize.sh
@@ -1,15 +1,54 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
+
+set -eux
 
 [[ -f bin/kustomize ]] && exit 0
 
-version=5.4.3
+if ! command -v sha256sum &>/dev/null; then
+    echo "ERROR: sha256sum not found. On macOS, install coreutils: brew install coreutils" >&2
+    exit 1
+fi
+
+version=v5.8.1
 arch=$(go env GOARCH)
 os=$(go env GOOS)
 
 mkdir -p ./bin
-curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_${os}_${arch}.tar.gz"
 
-tar -xzvf "kustomize_v${version}_${os}_${arch}.tar.gz"
-mv kustomize ./bin
+CHECKSUMS_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${version}/checksums.txt"
+CHECKSUMS_FILE="checksums.txt"
+BINARY_FILE="kustomize_${version}_${os}_${arch}.tar.gz"
+URL="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${version}/${BINARY_FILE}"
 
-rm "kustomize_v${version}_${os}_${arch}.tar.gz"
+# Download checksums file
+curl --proto '=https' --tlsv1.3 -sSfL \
+    --retry 3 --retry-delay 5 --max-time 120 \
+    -o "${CHECKSUMS_FILE}" "${CHECKSUMS_URL}"
+
+# Extract the checksum for this platform
+KUSTOMIZE_SHA256="$(grep "kustomize_${version}_${os}_${arch}\.tar\.gz$" "${CHECKSUMS_FILE}" | awk '{print $1;}')"
+if [[ -z "${KUSTOMIZE_SHA256}" ]]; then
+    echo >&2 "fatal: could not find checksum for ${BINARY_FILE} in ${CHECKSUMS_URL}"
+    rm -f "${CHECKSUMS_FILE}"
+    exit 1
+fi
+
+# Download binary
+curl --proto '=https' --tlsv1.3 -sSfL \
+    --retry 3 --retry-delay 5 --max-time 120 \
+    -o "${BINARY_FILE}" "${URL}"
+
+# Verify checksum before extraction
+checksum="$(sha256sum "${BINARY_FILE}" | awk '{print $1;}')"
+if [[ "${checksum}" != "${KUSTOMIZE_SHA256}" ]]; then
+    echo >&2 "fatal: ${URL} checksum '${checksum}' differs from expected '${KUSTOMIZE_SHA256}'"
+    rm -f "${BINARY_FILE}" "${CHECKSUMS_FILE}"
+    exit 1
+fi
+
+# Extract
+tar -xzvf "${BINARY_FILE}" -C ./bin
+
+chmod 0755 ./bin/kustomize
+
+rm -f "${BINARY_FILE}" "${CHECKSUMS_FILE}"


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

Harden binary downloads in 3 files:
- `hack/ensure-golangci-lint.sh`
- `hack/tools/install_kubebuilder.sh`
- `hack/tools/install_kustomize.sh`

**What this PR does / why we need it**:

- **Security**: Do dowloads using TLS 1.3 enforcement; download and verify official `checksums.txt` from GitHub releases
- **Reliability**: Add automatic retries (3x) with delays to persist through temporary network errors
- **Maintainability**: Use dynamic platform detection (`go env GOARCH/GOOS`) instead of hardcoded values; eliminate need to manually update checksums for new versions with use of official `checksums.txt`
- **Version Update**: Kubebuilder 2.2.0 → 4.14.0

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
