### PR TITLE
:seedling: Add image digest handling to release workflow and pin release artifact image with digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,10 +83,29 @@ jobs:
         git push origin ${RELEASE_VERSION}
         git push origin api/${RELEASE_VERSION}
         echo "Created tags ${RELEASE_VERSION} and api/${RELEASE_VERSION}"
+  build_ipam:
+    permissions:
+      contents: read
+      id-token: write
+    needs: push_release_tags
+    name: Build IPAM container image
+    if: github.repository == 'metal3-io/ip-address-manager'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
+    with:
+      image-name: "ip-address-manager"
+      pushImage: true
+      ref: ${{ needs.push_release_tags.outputs.release_tag }}
+      generate-sbom: true
+      sign-image: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
   release:
     name: create draft release
     runs-on: ubuntu-latest
-    needs: push_release_tags
+    needs: [push_release_tags, build_ipam]
     permissions:
       contents: write
     steps:
@@ -110,6 +129,7 @@ jobs:
     - name: generate release artifacts
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MANIFEST_DIGEST: ${{ needs.build_ipam.outputs['image-digest'] }}
       run: |
         make release
     - name: get release notes
@@ -131,22 +151,3 @@ jobs:
           --title "${RELEASE_TAG}" \
           --notes-file "${RELEASE_TAG}.md" \
           out/*
-
-  build_ipam:
-    permissions:
-      contents: read
-      id-token: write
-    needs: push_release_tags
-    name: Build IPAM container image
-    if: github.repository == 'metal3-io/ip-address-manager'
-    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
-    with:
-      image-name: "ip-address-manager"
-      pushImage: true
-      ref: ${{ needs.push_release_tags.outputs.release_tag }}
-      generate-sbom: true
-      sign-image: true
-    secrets:
-      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,12 @@ set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}:$(MANIFEST_TAG)"'\"@' ./config/default/manager_image_patch.yaml
 
+.PHONY: set-manifest-image-digest
+set-manifest-image-digest:
+	$(info Updating kustomize image patch file for manager resource)
+	@if [ -z "$(MANIFEST_DIGEST)" ]; then echo "MANIFEST_DIGEST is not set"; exit 1; fi
+	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}@$(MANIFEST_DIGEST)"'\"@' ./config/default/manager_image_patch.yaml
+
 
 .PHONY: set-manifest-pull-policy
 set-manifest-pull-policy:
@@ -336,7 +342,12 @@ release:
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "You have uncommitted changes"; exit 1; fi
 	git checkout "${RELEASE_TAG}"
-	MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image
+	@if [ -n "$(MANIFEST_DIGEST)" ]; then \
+		MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_DIGEST=$(MANIFEST_DIGEST) $(MAKE) set-manifest-image-digest; \
+	else \
+		echo "MANIFEST_DIGEST is not set, falling back to tag"; \
+		MANIFEST_IMG=$(CONTROLLER_IMG) MANIFEST_TAG=$(RELEASE_TAG) $(MAKE) set-manifest-image; \
+	fi
 	$(MAKE) release-manifests
 
 ## --------------------------------------


### PR DESCRIPTION
The reusable workflow https://github.com/metal3-io/project-infra/blob/main/.github/workflows/container-image-build.yml outputs and image-digest for built image. Change the release steps order so that we can consume the digest and pin release artifact image with digest instead of image tag. The release process falls back to image tag if digest is not set.


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
