### PR TITLE
:bug: Add uniqueness check for Preallocation at IPPool creation and validation times

### DIFF
--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -249,7 +249,8 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 		}
 	}
 
-	// Validate preAllocations IPs
+	// Validate preAllocations IPs.
+	ipToClaimName := make(map[netip.Addr]string, len(pool.Spec.PreAllocations))
 	for name, ipAddr := range pool.Spec.PreAllocations {
 		if err := validateIPAddress(ipAddr); err != nil {
 			allErrs = append(allErrs,
@@ -259,6 +260,23 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 					"is not a valid IP address",
 				),
 			)
+			continue
+		}
+
+		// Use netip.Addr.String() form as map key so that equivalent
+		// addresses with different textual representations (e.g. IPv6 with/without
+		// leading zeros) are detected as duplicates.
+		ipAddress, _ := netip.ParseAddr(string(ipAddr))
+		if existingClaim, exists := ipToClaimName[ipAddress]; exists {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "preAllocations", name),
+					ipAddr,
+					fmt.Sprintf("IP address is already pre-allocated to claim %q", existingClaim),
+				),
+			)
+		} else {
+			ipToClaimName[ipAddress] = name
 		}
 	}
 

--- a/internal/webhooks/v1alpha1/ippool_webhook_test.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook_test.go
@@ -308,6 +308,22 @@ func TestIPPoolValidation(t *testing.T) {
 			},
 		},
 		{
+			name:      "should succeed with unique preAllocation IPs",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"claim1": "192.168.0.10",
+						"claim2": "192.168.0.11",
+						"claim3": "192.168.0.12",
+					},
+				},
+			},
+		},
+		{
 			name:      "should succeed with random strategy when pool is bounded by start and end",
 			expectErr: false,
 			c: &ipamv1.IPPool{
@@ -413,6 +429,57 @@ func TestIPPoolValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "should fail when multiple claims have the same preAllocated IP",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"claim1": "192.168.0.10",
+						"claim2": "192.168.0.10",
+					},
+				},
+			},
+		},
+		{
+			name:      "should fail when IPv6 preAllocations differ only in textual representation",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{Start: &startAddr},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"claim1": "2001:db8::1",
+						"claim2": "2001:0db8:0000:0000:0000:0000:0000:0001",
+					},
+				},
+			},
+		},
+		{
+			name:      "should succeed when IPv6 preAllocations are genuinely different",
+			expectErr: false,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"claim1": "2001:db8::1",
+						"claim2": "2001:db8::2",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -439,6 +506,7 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 	invalidStartAddr := ipamv1.IPAddressStr("192.168.0.149")
 	invalidEndAddr := ipamv1.IPAddressStr("192.168.0.140")
 	subnet := ipamv1.IPSubnetStr("192.168.0.1/25")
+	v6Subnet := ipamv1.IPSubnetStr("2001:db8::/64")
 
 	tests := []struct {
 		name          string
@@ -617,6 +685,86 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 			oldPoolStatus: ipamv1.IPPoolStatus{
 				Allocations: map[string]ipamv1.IPAddressStr{
 					"inuse": ipamv1.IPAddressStr("192.168.0.30"),
+				},
+			},
+		},
+		{
+			name:      "should succeed when update has unique preAllocation IPs",
+			expectErr: false,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Start: &startAddr, End: &endAddr},
+				},
+				PreAllocations: map[string]ipamv1.IPAddressStr{
+					"claim1": ipamv1.IPAddressStr("192.168.0.2"),
+					"claim2": ipamv1.IPAddressStr("192.168.0.3"),
+				},
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Start: &startAddr, End: &endAddr},
+				},
+			},
+		},
+		{
+			name:      "should fail when update has duplicate preAllocation IPs",
+			expectErr: true,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Start: &startAddr, End: &endAddr},
+				},
+				PreAllocations: map[string]ipamv1.IPAddressStr{
+					"claim1": ipamv1.IPAddressStr("192.168.0.2"),
+					"claim2": ipamv1.IPAddressStr("192.168.0.2"),
+				},
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Start: &startAddr, End: &endAddr},
+				},
+			},
+		},
+		{
+			name:      "should fail when update has IPv6 duplicates with different textual representation",
+			expectErr: true,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Start: &startAddr, End: &endAddr},
+				},
+				PreAllocations: map[string]ipamv1.IPAddressStr{
+					"claim1": ipamv1.IPAddressStr("2001:db8::1"),
+					"claim2": ipamv1.IPAddressStr("2001:0db8:0000:0000:0000:0000:0000:0001"),
+				},
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Subnet: &v6Subnet},
+				},
+			},
+		},
+		{
+			name:      "should succeed when IPv6 preAllocations are genuinely different",
+			expectErr: false,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Subnet: &v6Subnet},
+				},
+				PreAllocations: map[string]ipamv1.IPAddressStr{
+					"claim1": ipamv1.IPAddressStr("2001:db8::1"),
+					"claim2": ipamv1.IPAddressStr("2001:db8::2"),
+				},
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				NamePrefix: "abcd",
+				Pools: []ipamv1.Pool{
+					{Subnet: &v6Subnet},
 				},
 			},
 		},


### PR DESCRIPTION
# Add uniqueness validation for IPPool preAllocation IP addresses

## Problem

When creating an IPPool with duplicate IP addresses in `preAllocations` (same IP mapped to different claim names), the webhook accepts the resource without error. At runtime the second claim silently fails to allocate.

There is no valid use-case for pre-allocating the same IP to multiple claims.

## Fix

Add validation in `validatePoolRanges()` (called by both `ValidateCreate` and `ValidateUpdate`) that rejects IPPools where multiple preAllocation entries map to the same IP address.

## Expected behavior after this PR

The `kubectl apply` in Step 1 is rejected by the validating webhook
with an error indicating the duplicate IP:

```
The IPPool "test-pool" is invalid:
  spec.preAllocations.claim-2: Invalid value: "192.168.1.10":
    IP address is already pre-allocated to claim "claim-1"
```

fixes #1440

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
