### PR TITLE
:bug: Validate IP requested through annotation is valid IP format

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -443,6 +443,14 @@ func (m *IPPoolManager) allocateAddress(addressClaim *ipamv1.IPClaim,
 	requestedIP := ipamv1.IPAddressStr(addressClaim.ObjectMeta.Annotations[IPAddressAnnotation])
 	isRequestedIPAllocated := false
 
+	if requestedIP != "" {
+		if net.ParseIP(string(requestedIP)) == nil {
+			msg := fmt.Sprintf("Invalid ipAddress annotation %q: not a valid IP address", requestedIP)
+			addressClaim.Status.ErrorMessage = ptr.To(msg)
+			return "", 0, nil, []ipamv1.IPAddressStr{}, errors.New(msg)
+		}
+	}
+
 	// Conflict-case, claim is preAllocated but has requested different IP
 	if requestedIP != "" && ipPreAllocated && !m.ipEqual(requestedIP, preAllocatedAddress) {
 		addressClaim.Status.ErrorMessage = ptr.To("PreAllocation and requested ip address are conflicting")
@@ -533,6 +541,22 @@ func (m *IPPoolManager) capiAllocateAddress(addressClaim *capipamv1.IPAddressCla
 
 	requestedIP := ipamv1.IPAddressStr(addressClaim.ObjectMeta.Annotations[IPAddressAnnotation])
 	isRequestedIPAllocated := false
+
+	if requestedIP != "" {
+		if net.ParseIP(string(requestedIP)) == nil {
+			msg := fmt.Sprintf("Invalid ipAddress annotation %q: not a valid IP address", requestedIP)
+			conditions := make([]metav1.Condition, 0, 1)
+			conditions = append(conditions, metav1.Condition{
+				Type:               capipamv1.IPAddressClaimReadyCondition,
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             capipamv1.IPAddressClaimReadyAllocationFailedReason,
+				Message:            msg,
+			})
+			addressClaim.SetConditions(conditions)
+			return "", 0, nil, errors.New(msg)
+		}
+	}
 
 	// Conflict-case, claim is preAllocated but has requested different IP
 	if requestedIP != "" && ipPreAllocated && !m.ipEqual(requestedIP, preAllocatedAddress) {

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -1930,14 +1930,15 @@ var _ = Describe("IPPool manager", func() {
 	)
 
 	type testCaseAllocateAddress struct {
-		ipPool             *ipamv1.IPPool
-		ipClaim            *ipamv1.IPClaim
-		addresses          map[ipamv1.IPAddressStr]string
-		expectedAddress    ipamv1.IPAddressStr
-		expectedPrefix     int
-		expectedGateway    *ipamv1.IPAddressStr
-		expectedDNSServers []ipamv1.IPAddressStr
-		expectError        bool
+		ipPool               *ipamv1.IPPool
+		ipClaim              *ipamv1.IPClaim
+		addresses            map[ipamv1.IPAddressStr]string
+		expectedAddress      ipamv1.IPAddressStr
+		expectedPrefix       int
+		expectedGateway      *ipamv1.IPAddressStr
+		expectedDNSServers   []ipamv1.IPAddressStr
+		expectError          bool
+		expectedErrorMessage *string
 	}
 
 	DescribeTable("Test AllocateAddress",
@@ -1951,6 +1952,10 @@ var _ = Describe("IPPool manager", func() {
 			)
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
+				if tc.expectedErrorMessage != nil {
+					Expect(tc.ipClaim.Status.ErrorMessage).NotTo(BeNil())
+					Expect(*tc.ipClaim.Status.ErrorMessage).To(Equal(*tc.expectedErrorMessage))
+				}
 				return
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -2417,16 +2422,42 @@ var _ = Describe("IPPool manager", func() {
 			},
 			expectError: true,
 		}),
+		Entry("Invalid ipAddress annotation", testCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipClaim: &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "not-a-valid-ip",
+					},
+				},
+			},
+			addresses:            map[ipamv1.IPAddressStr]string{},
+			expectError:          true,
+			expectedErrorMessage: ptr.To(`Invalid ipAddress annotation "not-a-valid-ip": not a valid IP address`),
+		}),
 	)
 
 	type testCapiCaseAllocateAddress struct {
-		ipPool          *ipamv1.IPPool
-		addresses       map[ipamv1.IPAddressStr]string
-		ipAddressClaim  *capipamv1.IPAddressClaim
-		expectedAddress ipamv1.IPAddressStr
-		expectedPrefix  int32
-		expectedGateway *ipamv1.IPAddressStr
-		expectError     bool
+		ipPool                   *ipamv1.IPPool
+		addresses                map[ipamv1.IPAddressStr]string
+		ipAddressClaim           *capipamv1.IPAddressClaim
+		expectedAddress          ipamv1.IPAddressStr
+		expectedPrefix           int32
+		expectedGateway          *ipamv1.IPAddressStr
+		expectError              bool
+		expectedConditionMessage string
 	}
 
 	DescribeTable("Test capiAllocateAddress",
@@ -2440,6 +2471,12 @@ var _ = Describe("IPPool manager", func() {
 			)
 			if tc.expectError {
 				Expect(err).To(HaveOccurred())
+				if tc.expectedConditionMessage != "" {
+					conditions := tc.ipAddressClaim.GetConditions()
+					Expect(conditions).NotTo(BeEmpty())
+					Expect(conditions[0].Message).To(Equal(tc.expectedConditionMessage))
+					Expect(conditions[0].Status).To(Equal(metav1.ConditionFalse))
+				}
 				return
 			}
 			Expect(err).NotTo(HaveOccurred())
@@ -2846,6 +2883,31 @@ var _ = Describe("IPPool manager", func() {
 				ipamv1.IPAddressStr("192.168.0.3"): "abcd",
 			},
 			expectError: true,
+		}),
+		Entry("Invalid ipAddress annotation", testCapiCaseAllocateAddress{
+			ipPool: &ipamv1.IPPool{
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:  24,
+					Gateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				},
+			},
+			ipAddressClaim: &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "TestRef",
+					Annotations: map[string]string{
+						IPAddressAnnotation: "not-a-valid-ip",
+					},
+				},
+			},
+			addresses:                map[ipamv1.IPAddressStr]string{},
+			expectError:              true,
+			expectedConditionMessage: `Invalid ipAddress annotation "not-a-valid-ip": not a valid IP address`,
 		}),
 	)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

When requesting IP through annotation the IPClaim or IPAddressClaim does not get added a proper error message. Currently the claims get an "Pool exhausted" error added to the claim's status and allocation fails. 

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

This PR adds a more descriptive error message and unit testing. 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
