### PR TITLE
:seedling: Make IPPool ClusterName field immutable and update IPAddress and IPClaim validation functions

### DIFF
--- a/internal/webhooks/v1alpha1/ipaddress_webhook.go
+++ b/internal/webhooks/v1alpha1/ipaddress_webhook.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -111,7 +112,6 @@ func (webhook *IPAddress) ValidateCreate(_ context.Context, ipAddress *ipamv1.IP
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *IPAddress) ValidateUpdate(_ context.Context, oldIPAddress, newIPAddress *ipamv1.IPAddress) (admission.Warnings, error) {
-	allErrs := field.ErrorList{}
 	if oldIPAddress == nil {
 		return nil, apierrors.NewInternalError(errors.New("unable to convert existing object"))
 	}
@@ -120,72 +120,18 @@ func (webhook *IPAddress) ValidateUpdate(_ context.Context, oldIPAddress, newIPA
 		return nil, apierrors.NewBadRequest("expected an IPAddress but got nil")
 	}
 
-	if newIPAddress.Spec.Address != oldIPAddress.Spec.Address {
-		allErrs = append(allErrs,
+	if !equality.Semantic.DeepEqual(oldIPAddress.Spec, newIPAddress.Spec) {
+		allErrs := field.ErrorList{
 			field.Invalid(
-				field.NewPath("spec", "address"),
-				newIPAddress.Spec.Address,
+				field.NewPath("spec"),
+				newIPAddress.Spec,
 				"cannot be modified",
 			),
-		)
+		}
+		return nil, apierrors.NewInvalid(ipamv1.GroupVersion.WithKind("IPAddress").GroupKind(), newIPAddress.Name, allErrs)
 	}
 
-	if newIPAddress.Spec.Pool.Name != oldIPAddress.Spec.Pool.Name {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPAddress.Spec.Pool,
-				"cannot be modified",
-			),
-		)
-	} else if newIPAddress.Spec.Pool.Namespace != oldIPAddress.Spec.Pool.Namespace {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPAddress.Spec.Pool,
-				"cannot be modified",
-			),
-		)
-	} else if newIPAddress.Spec.Pool.Kind != oldIPAddress.Spec.Pool.Kind {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPAddress.Spec.Pool,
-				"cannot be modified",
-			),
-		)
-	}
-
-	if newIPAddress.Spec.Claim.Name != oldIPAddress.Spec.Claim.Name {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "claim"),
-				newIPAddress.Spec.Claim,
-				"cannot be modified",
-			),
-		)
-	} else if newIPAddress.Spec.Claim.Namespace != oldIPAddress.Spec.Claim.Namespace {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "claim"),
-				newIPAddress.Spec.Claim,
-				"cannot be modified",
-			),
-		)
-	} else if newIPAddress.Spec.Claim.Kind != oldIPAddress.Spec.Claim.Kind {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "claim"),
-				newIPAddress.Spec.Claim,
-				"cannot be modified",
-			),
-		)
-	}
-
-	if len(allErrs) == 0 {
-		return nil, nil
-	}
-	return nil, apierrors.NewInvalid(ipamv1.GroupVersion.WithKind("IPAddress").GroupKind(), newIPAddress.Name, allErrs)
+	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/internal/webhooks/v1alpha1/ipclaim_webhook.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +85,6 @@ func (webhook *IPClaim) ValidateCreate(_ context.Context, ipClaim *ipamv1.IPClai
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *IPClaim) ValidateUpdate(_ context.Context, oldIPClaim, newIPClaim *ipamv1.IPClaim) (admission.Warnings, error) {
-	allErrs := field.ErrorList{}
 	if oldIPClaim == nil {
 		return nil, apierrors.NewInternalError(errors.New("unable to convert existing object"))
 	}
@@ -93,27 +93,13 @@ func (webhook *IPClaim) ValidateUpdate(_ context.Context, oldIPClaim, newIPClaim
 		return nil, apierrors.NewBadRequest("expected an IPClaim but got nil")
 	}
 
-	if newIPClaim.Spec.Pool.Name != oldIPClaim.Spec.Pool.Name {
+	allErrs := field.ErrorList{}
+
+	if !equality.Semantic.DeepEqual(oldIPClaim.Spec, newIPClaim.Spec) {
 		allErrs = append(allErrs,
 			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPClaim.Spec.Pool,
-				"cannot be modified",
-			),
-		)
-	} else if newIPClaim.Spec.Pool.Namespace != oldIPClaim.Spec.Pool.Namespace {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPClaim.Spec.Pool,
-				"cannot be modified",
-			),
-		)
-	} else if newIPClaim.Spec.Pool.Kind != oldIPClaim.Spec.Pool.Kind {
-		allErrs = append(allErrs,
-			field.Invalid(
-				field.NewPath("spec", "pool"),
-				newIPClaim.Spec.Pool,
+				field.NewPath("spec"),
+				newIPClaim.Spec,
 				"cannot be modified",
 			),
 		)

--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -98,6 +98,22 @@ func (webhook *IPPool) ValidateUpdate(_ context.Context, oldIPPool, newIPPool *i
 		)
 	}
 
+	// Prevent changes to ClusterName if it was set before. Allow
+	// setting ClusterName if it was NOT set before, as this allows
+	// users to bind the IPPool to a cluster after creation.
+	// Changing the ClusterName of an IPPool causes a change in IPPool's
+	// ownerReference. There is no use case where changing ownerReference
+	// from one cluster to another is required.
+	if oldIPPool.Spec.ClusterName != nil && !reflect.DeepEqual(newIPPool.Spec.ClusterName, oldIPPool.Spec.ClusterName) {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "clusterName"),
+				newIPPool.Spec.ClusterName,
+				"cannot be modified",
+			),
+		)
+	}
+
 	// Treat an empty strategy as the default (sequential) so legacy objects
 	// stored before this field existed cannot be silently switched, and so
 	// the comparison is symmetric on both sides.

--- a/internal/webhooks/v1alpha1/ippool_webhook_test.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook_test.go
@@ -21,6 +21,7 @@ import (
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -468,6 +469,24 @@ func TestIPPoolUpdateValidation(t *testing.T) {
 			oldPoolSpec: &ipamv1.IPPoolSpec{
 				NamePrefix: "abcd",
 			},
+		},
+		{
+			name:      "should fail when clusterName value changes",
+			expectErr: true,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				ClusterName: ptr.To("new-cluster"),
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{
+				ClusterName: ptr.To("old-cluster"),
+			},
+		},
+		{
+			name:      "should succeed when clusterName is added when it was previously empty",
+			expectErr: false,
+			newPoolSpec: &ipamv1.IPPoolSpec{
+				ClusterName: ptr.To("new-cluster"),
+			},
+			oldPoolSpec: &ipamv1.IPPoolSpec{},
 		},
 		{
 			name:      "should fail when updating to invalid range (start > end)",


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

**IPPool webhook** (`ippool_webhook.go`):
- Added immutability check for `spec.clusterName` — rejects updates if the field was previously set and is being changed

**IPAddress webhook** (`ipaddress_webhook.go`):
- Replaced per-field immutability checks with a single `reflect.DeepEqual` on the entire spec
- All IPAddress spec fields (Address, Pool, Claim, Prefix, Gateway, DNSServers) are set at allocation time and should never be modified

**IPClaim webhook** (`ipclaim_webhook.go`):
- Replaced per-field Pool reference checks with `reflect.DeepEqual` on the entire spec
- IPClaim spec only contains Pool, which must remain immutable after creation

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
