### PR TITLE
:seedling: Make codegen.sh mount host repo with ro

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -12,9 +12,16 @@ CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
-    # we need to tell git its OK to use dir owned by someone else
-    git config --global safe.directory "${WORKDIR}"
     export XDG_CACHE_HOME="/tmp/.cache"
+
+    # Copy source to a writable temp directory so make generate can write
+    # generated files without requiring a read-write host mount.
+    # This script is a verification check only — generated output is not
+    # written back to the host working tree.
+    CODEGEN_DIR="$(mktemp -d -t codegen.XXXXXX)"
+    cp -a . "${CODEGEN_DIR}"
+    cd "${CODEGEN_DIR}"
+    git config --global safe.directory "${CODEGEN_DIR}"
 
     INPUT_FILES="$(git ls-files config) $(git ls-files | grep zz_generated)"
     cksum ${INPUT_FILES} > "${ARTIFACTS}/lint.cksums.before"
@@ -26,7 +33,7 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:rw,z" \
+        --volume "${PWD}:${WORKDIR}:ro,z" \
         --entrypoint sh \
         --workdir "${WORKDIR}" \
         docker.io/golang:1.25 \


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->
Make codegen.sh mount host repo with ro instead of rw. Using ro (read-only) is safer than rw  (read-write). 

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
