### PR TITLE
🌱 Removed zizmor inline ignore & set dependabot cooldown to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,13 +20,13 @@ updates:
   - dependency-name: "*"
     update-types: ["version-update:semver-major"]
   cooldown:
-    default-days: 7
+    default-days: 3
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
+- package-ecosystem: "gomod"
   directories:
   - "/"
   - "/api"
@@ -54,6 +54,8 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  cooldown:
+    default-days: 3
   labels:
   - "ok-to-test"
 ## main branch config ends here
@@ -75,13 +77,13 @@ updates:
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   cooldown:
-    default-days: 7
+    default-days: 3
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
+- package-ecosystem: "gomod"
   directories:
   - "/"
   - "/api"
@@ -105,6 +107,8 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  cooldown:
+    default-days: 3
   labels:
   - "ok-to-test"
 
@@ -127,13 +131,13 @@ updates:
   - dependency-name: "*"
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   cooldown:
-    default-days: 7
+    default-days: 3
   commit-message:
     prefix: ":seedling:"
   labels:
   - "ok-to-test"
   # Go
-- package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown]
+- package-ecosystem:
   directories:
   - "/"
   - "/api"
@@ -157,6 +161,8 @@ updates:
     update-types: ["version-update:semver-major", "version-update:semver-minor"]
   commit-message:
     prefix: ":seedling:"
+  cooldown:
+    default-days: 3
   labels:
   - "ok-to-test"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository == 'metal3-io/ip-address-manager'
     steps:
     - name: Checkout code
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2 # zizmor: ignore[artipacked]
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,9 +28,12 @@ jobs:
     - name: Run zizmor (SARIF)
       if: github.event_name == 'push'
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        config: .zizmor.yml
     # Block PRs with findings
     - name: Run zizmor (PR check)
       if: github.event_name == 'pull_request'
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:
         advanced-security: false
+        config: .zizmor.yml

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor configuration file
+# This file controls zizmor automation rules such as Dependabot throttling.
+# See zizmor documentation for more details: https://docs.zizmor.sh/
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+
+  # persist-credentials needed later in the workflow
+  artipacked:
+    ignore:
+    - release.yaml


### PR DESCRIPTION
Removed the `# zizmor: ignore[artipacked]` inline suppression comment from `.github/workflows/release.yaml`. In addition, the cooldown on dependabot was changed from 7 days to 3 days. Instead of suppressing the zizmor warning with `zizmor: ignored`, this adds a proper `.zizmor.yml` config at the repo root.  Both of the ignore/warnings are now handled via its own targeted ignore rule in `.zizmor.yml` at the repo root instead. The workflow at `.github/workflows/zizmor.yml` picks it up via the `config:` input.

