### PR TITLE
:seedling: Remove git config modification from codegen.sh

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -19,11 +19,13 @@ if [ "${IS_CONTAINER}" != "false" ]; then
     # This script is a verification check only — generated output is not
     # written back to the host working tree.
     CODEGEN_DIR="$(mktemp -d -t codegen.XXXXXX)"
+    # This part is run outside of container and generated files should be
+    # cleaned up just in case this is run locally and not in test environment.
+    trap 'rm -rf "${CODEGEN_DIR}"' EXIT
     cp -a . "${CODEGEN_DIR}"
     cd "${CODEGEN_DIR}"
-    git config --global safe.directory "${CODEGEN_DIR}"
 
-    INPUT_FILES="$(git ls-files config) $(git ls-files | grep zz_generated)"
+    INPUT_FILES="$(find config -type f) $(find . -name 'zz_generated*' -type f)"
     cksum ${INPUT_FILES} > "${ARTIFACTS}/lint.cksums.before"
     export VERBOSE="--verbose"
     make generate

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -15,9 +15,12 @@ WORKDIR="${WORKDIR:-/workdir}"
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME=/tmp/.cache
 
-    mkdir /tmp/gomod
-    cp -r . /tmp/gomod
-    cd /tmp/gomod
+    GOMOD_DIR="$(mktemp -d -t gomod.XXXXXX)"
+    # This part is run outside of container and generated files should be
+    # cleaned up just in case this is run locally and not in test environment.
+    trap 'rm -rf "${GOMOD_DIR}"' EXIT
+    cp -r . "${GOMOD_DIR}"
+    cd "${GOMOD_DIR}"
 
     STATUS="$(git status --porcelain)"
     if [ -n "${STATUS}" ]; then

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -9,9 +9,12 @@ WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME=/tmp/.cache
-    mkdir /tmp/unit
-    cp -r ./* /tmp/unit
-    cd /tmp/unit
+    UNIT_DIR="$(mktemp -d -t unit.XXXXXX)"
+    # This part is run outside of container and generated files should be
+    # cleaned up just in case this is run locally and not in test environment.
+    trap 'rm -rf "${UNIT_DIR}"' EXIT
+    cp -r ./* "${UNIT_DIR}"
+    cd "${UNIT_DIR}"
     make unit
 else
     "${CONTAINER_RUNTIME}" run --rm \


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

Remove git config modification from `codegen.sh`.
In `unit.sh`, `gomod.sh` and `codegen.sh ` temp directories are created outside of container on the host. This PR adds a trap that makes sure the temporary files are removed once the script stops running. These scripts are mostly used for CI but can also be run locally. For the local runs it's important to clean up the directories.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
