### PR TITLE
:seedling: Remove unnecessary RBACs from controller and add e2e test

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,17 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -36,19 +25,10 @@ rules:
   - list
   - watch
 - apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters/status
-  verbs:
-  - get
-- apiGroups:
   - ipam.cluster.x-k8s.io
   resources:
   - ipaddressclaims
-  - ipaddresses
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch
@@ -58,20 +38,27 @@ rules:
   - ipam.cluster.x-k8s.io
   resources:
   - ipaddressclaims/status
-  - ipaddresses/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
+  - ipam.cluster.x-k8s.io
   - ipam.metal3.io
   resources:
   - ipaddresses
-  - ipclaims
-  - ippools
   verbs:
   - create
   - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ipclaims
+  verbs:
   - get
   - list
   - patch
@@ -80,10 +67,25 @@ rules:
 - apiGroups:
   - ipam.metal3.io
   resources:
-  - ipaddresses/status
   - ipclaims/status
-  - ippools/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ippools
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ipam.metal3.io
+  resources:
+  - ippools/status
+  verbs:
+  - get
+  - patch

--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -53,19 +53,15 @@ type IPPoolReconciler struct {
 	WatchFilterValue string
 }
 
-// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools,verbs=get;list;watch;patch;delete
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ippools/status,verbs=get;patch
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipclaims,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipclaims/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ipam.metal3.io,resources=ipaddresses,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddressclaims/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ipam.cluster.x-k8s.io,resources=ipaddresses,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
 // Reconcile handles IPPool events.
 func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -79,6 +79,7 @@ type CreateIPPoolInput struct {
 	DNSServers     []string
 	NamePrefix     string
 	PreAllocations map[string]ipamv1.IPAddressStr
+	ClusterName    string
 }
 
 // createIPPool creates an IPPool resource from the given config.
@@ -122,6 +123,10 @@ func createIPPool(ctx context.Context, clusterProxy framework.ClusterProxy, cfg 
 
 	if cfg.PreAllocations != nil {
 		spec.PreAllocations = cfg.PreAllocations
+	}
+
+	if cfg.ClusterName != "" {
+		spec.ClusterName = &cfg.ClusterName
 	}
 
 	ipPool := &ipamv1.IPPool{

--- a/test/e2e/owner_ref_enforcement_test.go
+++ b/test/e2e/owner_ref_enforcement_test.go
@@ -1,0 +1,379 @@
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	kind "sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cmd"
+)
+
+// This test verifies that IPAM correctly sets ownerReferences when the
+// OwnerReferencesPermissionEnforcement admission plugin is enabled.
+// This plugin requires controllers to have delete permission to set ownerReferences.
+// See: https://github.com/metal3-io/baremetal-operator/issues/3304
+
+// The controller fetches the Cluster
+// object via the controller-runtime cache. The cache requires list+watch RBAC on
+// clusters.cluster.x-k8s.io. Without list+watch, the cache informer
+// fails to sync and the controller cannot fetch the Cluster, causing it to return
+// early without processing any IPClaims for that pool.
+
+var _ = Describe("IPAM with OwnerReferencesPermissionEnforcement", Label("ipam", "rbac"), func() {
+	var (
+		clusterName    string
+		kubeconfigPath string
+		clusterProxy   framework.ClusterProxy
+		kindProvider   *kind.Provider
+	)
+
+	BeforeEach(func() {
+		validateGlobals()
+		clusterName = "ipam-ownerref"
+
+		By("Creating kind cluster with OwnerReferencesPermissionEnforcement enabled")
+		kindProvider, kubeconfigPath = createKindClusterWithOwnerRefEnforcement(clusterName)
+
+		By("Loading IPAM image into the kind cluster")
+		err := bootstrap.LoadImagesToKindCluster(ctx, bootstrap.LoadImagesToKindClusterInput{
+			Name:   clusterName,
+			Images: e2eConfig.Images,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Setting up cluster proxy")
+		clusterProxy = framework.NewClusterProxy("ownerref-test", kubeconfigPath, initScheme())
+		Expect(clusterProxy).ToNot(BeNil())
+
+		By("Initializing IPAM on cluster")
+		clusterctl.Init(ctx, clusterctl.InitInput{
+			KubeconfigPath:        clusterProxy.GetKubeconfigPath(),
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			CoreProvider:          "cluster-api",
+			BootstrapProviders:    []string{"kubeadm"},
+			ControlPlaneProviders: []string{"kubeadm"},
+			IPAMProviders:         e2eConfig.IPAMProviders(),
+			LogFolder:             filepath.Join(artifactFolder, "clusters", clusterName),
+		})
+
+		By("Waiting for IPAM controller")
+		controllersDeployments := framework.GetControllerDeployments(ctx, framework.GetControllerDeploymentsInput{
+			Lister: clusterProxy.GetClient(),
+		})
+		for _, deployment := range controllersDeployments {
+			framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{
+				Getter:     clusterProxy.GetClient(),
+				Deployment: deployment,
+			}, e2eConfig.GetIntervals("default", "wait-controllers")...)
+		}
+	})
+
+	AfterEach(func() {
+		if skipCleanup {
+			Logf("Skipping cleanup of kind cluster %s (SKIP_RESOURCE_CLEANUP=true)", clusterName)
+			return
+		}
+		if clusterProxy != nil {
+			clusterProxy.Dispose(ctx)
+		}
+		if kindProvider != nil {
+			Expect(kindProvider.Delete(clusterName, kubeconfigPath)).To(Succeed())
+		}
+		if kubeconfigPath != "" {
+			os.Remove(kubeconfigPath)
+		}
+	})
+
+	It("Should allocate IPs with valid ownerReferences", func() {
+		cl := clusterProxy.GetClient()
+		namespace := testNamespace()
+
+		By("Creating test namespace")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}
+		err := cl.Create(ctx, ns)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Creating a CAPI Cluster as ownerReference target")
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ownerref-test-cluster",
+				Namespace: namespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+					APIGroup: "infrastructure.cluster.x-k8s.io",
+					Kind:     "GenericInfrastructureCluster",
+					Name:     "ownerref-test-infra",
+				},
+			},
+		}
+		Expect(cl.Create(ctx, cluster)).To(Succeed())
+
+		By("Creating an IPPool with ClusterName set")
+		ipPool := createIPPool(ctx, clusterProxy, CreateIPPoolInput{
+			Name:        "test-pool",
+			Namespace:   namespace,
+			Start:       "192.168.10.10",
+			End:         "192.168.10.100",
+			Subnet:      "192.168.10.0/24",
+			Prefix:      24,
+			Gateway:     "192.168.10.1",
+			DNSServers:  []string{"8.8.8.8"},
+			NamePrefix:  "ownerref-ip",
+			ClusterName: cluster.Name,
+		})
+
+		By("Creating an IPClaim")
+		ipClaim := createIPClaim(ctx, clusterProxy, ipPool.Name, "test-claim", namespace)
+
+		By("Waiting for IPClaim to get allocated address")
+		Eventually(func(g Gomega) {
+			retrieved := &ipamv1.IPClaim{}
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), retrieved)).To(Succeed())
+			g.Expect(retrieved.Status.Address).ToNot(BeNil())
+		}, e2eConfig.GetIntervals("default", "wait-ippool")...).Should(Succeed())
+
+		By("Verifying IPPool has Cluster ownerReference")
+		Eventually(func(g Gomega) {
+			pool := &ipamv1.IPPool{}
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipPool), pool)).To(Succeed())
+			g.Expect(pool.OwnerReferences).ToNot(BeEmpty(), "IPPool should have ownerReference")
+			g.Expect(pool.OwnerReferences).To(ContainElement(SatisfyAll(
+				HaveField("Kind", Equal("Cluster")),
+				HaveField("Name", Equal(cluster.Name)),
+			)), "IPPool should have Cluster ownerReference")
+		}, e2eConfig.GetIntervals("default", "wait-ippool")...).Should(Succeed())
+
+		By("Verifying IPAddress has ownerReferences")
+		updatedClaim := &ipamv1.IPClaim{}
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), updatedClaim)).To(Succeed())
+
+		ipAddr := &ipamv1.IPAddress{}
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Namespace: updatedClaim.Status.Address.Namespace,
+			Name:      updatedClaim.Status.Address.Name,
+		}, ipAddr)).To(Succeed())
+
+		Expect(ipAddr.OwnerReferences).ToNot(BeEmpty(), "IPAddress should have ownerReferences")
+		Expect(net.ParseIP(string(ipAddr.Spec.Address))).ToNot(BeNil(), "Should be valid IP")
+	})
+})
+
+var _ = Describe("IPClaim with pre-existing ownerReference", Label("ipam", "rbac"), func() {
+	var namespace string
+
+	BeforeEach(func() {
+		namespace = testNamespace()
+		validateGlobals()
+		cl := bootstrapClusterProxy.GetClient()
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}
+		err := cl.Create(ctx, ns)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		cleanupNamespace(ctx, bootstrapClusterProxy.GetClient(), namespace)
+	})
+
+	It("Should allocate an IP when IPClaim has an ownerReference", func() {
+		cl := bootstrapClusterProxy.GetClient()
+
+		By("Creating an IPPool")
+		ipPool := createIPPool(ctx, bootstrapClusterProxy, CreateIPPoolInput{
+			Name:       "test-pool-ownerref",
+			Namespace:  namespace,
+			Start:      "192.168.5.10",
+			End:        "192.168.5.100",
+			Subnet:     "192.168.5.0/24",
+			Prefix:     24,
+			Gateway:    "192.168.5.1",
+			DNSServers: []string{"8.8.8.8"},
+			NamePrefix: "ownerref-test",
+		})
+
+		By("Creating a ConfigMap to serve as owner")
+		owner := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "owner-cm",
+				Namespace: namespace,
+			},
+			Data: map[string]string{"key": "value"},
+		}
+		Expect(cl.Create(ctx, owner)).To(Succeed())
+
+		// Re-fetch to get the UID
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(owner), owner)).To(Succeed())
+
+		By("Creating an IPClaim with an ownerReference to the ConfigMap")
+		ipClaim := &ipamv1.IPClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "claim-with-ownerref",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       owner.Name,
+						UID:        owner.UID,
+					},
+				},
+			},
+			Spec: ipamv1.IPClaimSpec{
+				Pool: corev1.ObjectReference{
+					Name:      ipPool.Name,
+					Namespace: namespace,
+				},
+			},
+		}
+		Expect(cl.Create(ctx, ipClaim)).To(Succeed())
+
+		By("Waiting for IPClaim to get an allocated address")
+		Eventually(func(g Gomega) {
+			retrieved := &ipamv1.IPClaim{}
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), retrieved)).To(Succeed())
+			g.Expect(retrieved.Status.Address).ToNot(BeNil(), "IPClaim with ownerReference should get an address allocated")
+		}, e2eConfig.GetIntervals("default", "wait-ippool")...).Should(Succeed())
+
+		By("Verifying the IPAddress was created")
+		updatedClaim := &ipamv1.IPClaim{}
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), updatedClaim)).To(Succeed())
+
+		ipAddr := &ipamv1.IPAddress{}
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Namespace: updatedClaim.Status.Address.Namespace,
+			Name:      updatedClaim.Status.Address.Name,
+		}, ipAddr)).To(Succeed())
+		Expect(net.ParseIP(string(ipAddr.Spec.Address))).ToNot(BeNil(), "Should be valid IP")
+	})
+
+	It("Should allocate an IP when IPClaim has a controller ownerReference", func() {
+		cl := bootstrapClusterProxy.GetClient()
+
+		By("Creating an IPPool")
+		ipPool := createIPPool(ctx, bootstrapClusterProxy, CreateIPPoolInput{
+			Name:       "test-pool-ctrl-ownerref",
+			Namespace:  namespace,
+			Start:      "192.168.6.10",
+			End:        "192.168.6.100",
+			Subnet:     "192.168.6.0/24",
+			Prefix:     24,
+			Gateway:    "192.168.6.1",
+			DNSServers: []string{"8.8.8.8"},
+			NamePrefix: "ctrl-ownerref",
+		})
+
+		By("Creating a ConfigMap to serve as controller owner")
+		owner := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ctrl-owner-cm",
+				Namespace: namespace,
+			},
+			Data: map[string]string{"key": "value"},
+		}
+		Expect(cl.Create(ctx, owner)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(owner), owner)).To(Succeed())
+
+		By("Creating an IPClaim with controller: true ownerReference")
+		trueVal := true
+		ipClaim := &ipamv1.IPClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "claim-ctrl-ownerref",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "v1",
+						Kind:               "ConfigMap",
+						Name:               owner.Name,
+						UID:                owner.UID,
+						Controller:         &trueVal,
+						BlockOwnerDeletion: &trueVal,
+					},
+				},
+			},
+			Spec: ipamv1.IPClaimSpec{
+				Pool: corev1.ObjectReference{
+					Name:      ipPool.Name,
+					Namespace: namespace,
+				},
+			},
+		}
+		Expect(cl.Create(ctx, ipClaim)).To(Succeed())
+
+		By("Waiting for IPClaim to get an allocated address")
+		Eventually(func(g Gomega) {
+			retrieved := &ipamv1.IPClaim{}
+			g.Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), retrieved)).To(Succeed())
+			g.Expect(retrieved.Status.Address).ToNot(BeNil(), "IPClaim with controller ownerReference should get an address allocated")
+		}, e2eConfig.GetIntervals("default", "wait-ippool")...).Should(Succeed())
+
+		By("Verifying the IPAddress was created")
+		updatedClaim := &ipamv1.IPClaim{}
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(ipClaim), updatedClaim)).To(Succeed())
+
+		ipAddr := &ipamv1.IPAddress{}
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Namespace: updatedClaim.Status.Address.Namespace,
+			Name:      updatedClaim.Status.Address.Name,
+		}, ipAddr)).To(Succeed())
+		Expect(net.ParseIP(string(ipAddr.Spec.Address))).ToNot(BeNil(), "Should be valid IP")
+	})
+})
+
+// createKindClusterWithOwnerRefEnforcement creates a kind cluster with the
+// OwnerReferencesPermissionEnforcement admission plugin enabled.
+func createKindClusterWithOwnerRefEnforcement(name string) (*kind.Provider, string) {
+	kubeconfigFile, err := os.CreateTemp("", "e2e-ownerref-kind-")
+	Expect(err).ToNot(HaveOccurred())
+	kubeconfigPath := kubeconfigFile.Name()
+	kubeconfigFile.Close()
+
+	cfg := &kindv1.Cluster{
+		Nodes: []kindv1.Node{
+			{
+				Role: kindv1.ControlPlaneRole,
+				KubeadmConfigPatches: []string{
+					`kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    enable-admission-plugins: "NodeRestriction,OwnerReferencesPermissionEnforcement"`,
+				},
+			},
+		},
+	}
+	kindv1.SetDefaultsCluster(cfg)
+
+	provider := kind.NewProvider(kind.ProviderWithLogger(cmd.NewLogger()))
+	err = provider.Create(
+		name,
+		kind.CreateWithKubeconfigPath(kubeconfigPath),
+		kind.CreateWithV1Alpha4Config(cfg),
+		kind.CreateWithNodeImage(fmt.Sprintf("%s:%s", bootstrap.DefaultNodeImageRepository, bootstrap.DefaultNodeImageVersion)),
+		kind.CreateWithRetain(true),
+	)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(kubeconfigPath).To(BeAnExistingFile())
+
+	return provider, kubeconfigPath
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -14,6 +14,7 @@ require (
 	sigs.k8s.io/cluster-api v1.13.2
 	sigs.k8s.io/cluster-api/test v1.13.2
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/kind v0.31.0
 )
 
 require (
@@ -120,7 +121,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kind v0.31.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -14,6 +14,7 @@ require (
 	sigs.k8s.io/cluster-api/api v1.14.0-rc.1
 	sigs.k8s.io/cluster-api/test v1.14.0-rc.1
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/kind v0.32.0
 )
 
 require (
@@ -125,7 +126,6 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/cluster-api v1.14.0-rc.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kind v0.32.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect


### PR DESCRIPTION
This change removes unnecessary RBAC permissions from the IPAM controller and adds e2e test coverage for ownerReference handling with Kubernetes' `OwnerReferencesPermissionEnforcement` admission plugin.

## What this PR does / why we need it

**Reduced RBAC Permissions**
- Removed `events` resource permissions
- Removed `clusters/status` permissions
- Removed `ipaddresses/status` permissions
- Removed patch/update permissions on `IPPool/status`
- Removed patch permission on `ipaddresses`
- Removed create/delete permissions from `ipclaim` and `ipaddressclaim`
- Removed create/update permissions from `ippool`
- Removed update permission from `ippool/status`

**New E2E Test**

Suite 1: OwnerReferencesPermissionEnforcement:
  - Creates a dedicated kind cluster with the `OwnerReferencesPermissionEnforcement` admission plugin enabled
  - Verifies that:
    - IPPool objects are correctly assigned ownerReferences to Cluster objects when `ClusterName` is set
    - IPAddress objects have valid ownerReferences set during allocation
    - IP allocation succeeds despite the stricter admission plugin enforcement

Suite 2: IPClaim with Pre-existing OwnerReference:
  - Verifies that claims with existing ownerReferences are processed correctly
  - Tests both regular and controller-owned references on IPClaims
  - Ensures allocation works regardless of existing ownership


**Test Utilities**
- Added `ClusterName` field to `CreateIPPoolInput` struct


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
