### PR TITLE
:seedling:  Pin gcrane in verify-release.sh and add renovate to update it

### DIFF
--- a/hack/renovate-validator.sh
+++ b/hack/renovate-validator.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Validates renovate.json configuration using renovate-config-validator.
+# Requires Node.js 22+ for Renovate v40.
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+WORKDIR="${WORKDIR:-/workdir}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    npx --yes -p renovate renovate-config-validator
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --entrypoint sh \
+        --workdir "${WORKDIR}" \
+        docker.io/node:24-alpine \
+        "${WORKDIR}"/hack/renovate-validator.sh "$@"
+fi

--- a/hack/renovate-validator.sh
+++ b/hack/renovate-validator.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Validates renovate.json configuration using renovate-config-validator.
+# Requires Node.js 22+ for Renovate v40.
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    npx --yes -p renovate renovate-config-validator
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir "/workdir" \
+        docker.io/node:24-alpine \
+        /workdir/hack/renovate-validator.sh "$@"
+fi

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -138,7 +138,7 @@ if [[ -n "${CONTAINER_RUNTIME}" ]]; then
     declare -a GCRANE_CMD=(
         "${CONTAINER_RUNTIME}" run --rm
         --pull always
-        gcr.io/go-containerregistry/gcrane:latest
+        gcr.io/go-containerregistry/gcrane:v0.21.7@sha256:9f84ccb966ace4576dcd72543cc980056d037e499d5f389cd39a78e4b04740a6
     )
     declare -a OSVSCANNER_CMD=(
         "${CONTAINER_RUNTIME}" run --rm

--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -135,10 +135,12 @@ if [[ -n "${CONTAINER_RUNTIME}" ]]; then
     required_tools+=(
         "${CONTAINER_RUNTIME}"
     )
+    GCRANE_VERSION="v0.21.7"
+    GCRANE_SHA="sha256:9f84ccb966ace4576dcd72543cc980056d037e499d5f389cd39a78e4b04740a6"
     declare -a GCRANE_CMD=(
         "${CONTAINER_RUNTIME}" run --rm
         --pull always
-        gcr.io/go-containerregistry/gcrane:latest
+        "gcr.io/go-containerregistry/gcrane:${GCRANE_VERSION}@${GCRANE_SHA}"
     )
     declare -a OSVSCANNER_CMD=(
         "${CONTAINER_RUNTIME}" run --rm

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
+  "baseBranchPatterns": [
+    "main",
+    "release-1.12",
+    "release-1.13"
+  ],
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "prCreation": "immediate",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "automerge": false,
+  "labels": [
+    "ok-to-test"
+  ],
+  "commitMessagePrefix": ":seedling: ",
+  "semanticCommits": "disabled",
+  "packageRules": [
+    {
+      "matchBaseBranches": [
+        "main"
+      ],
+      "description": "run before 6am on Mondays",
+      "schedule": [
+        "* 0-5 * * 1"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release-1.12",
+        "release-1.13"
+      ],
+      "description": "run before 6am every day",
+      "schedule": [
+        "* 0-5 * * *"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump container image digests in shell scripts",
+      "managerFilePatterns": [
+        "hack/verify-release\\.sh$"
+      ],
+      "matchStrings": [
+        "gcr\\.io/(?<depName>[^:]+):(?<currentValue>[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://gcr.io"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
+  "baseBranchPatterns": [
+    "main",
+    "release-1.12",
+    "release-1.13"
+  ],
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "prCreation": "immediate",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "automerge": false,
+  "labels": [
+    "ok-to-test"
+  ],
+  "commitMessagePrefix": ":seedling: ",
+  "semanticCommits": "disabled",
+  "packageRules": [
+    {
+      "matchBaseBranches": [
+        "main"
+      ],
+      "description": "run before 6am on Mondays",
+      "schedule": [
+        "* 0-5 * * 1"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release-1.12",
+        "release-1.13"
+      ],
+      "description": "run before 6am every day",
+      "schedule": [
+        "* 0-5 * * *"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Bump gcrane container image digest in verify-release.sh",
+      "managerFilePatterns": [
+        "hack/verify-release\\.sh$"
+      ],
+      "matchStrings": [
+        "GCRANE_VERSION=\"(?<currentValue>[^\"]+)\"\\s*\\n\\s*GCRANE_SHA=\"(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "depNameTemplate": "go-containerregistry/gcrane",
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://gcr.io"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

Pin gcrane with image digest in `verify-release.sh` and add renovate to update the pinned version. The reason gcrane image is not pinned is that the images don't get maintained too long and it has been easier to leave it unpinned. I'm suggesting we pin the version and add renovate to upgrade the version when there is a new on. I could get a clear picture how long the images are actually available but updating to new version should be at least often enough to not have the digest go stale on us. 


<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
