### PR TITLE
:bug: Add namespace validation to IPClaim and IPPool reconciliation

### DIFF
--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -224,6 +224,9 @@ func (r *IPPoolReconciler) IPClaimToIPPool(_ context.Context, obj client.Object)
 			if namespace == "" {
 				namespace = m3ipc.Namespace
 			}
+			if namespace != m3ipc.Namespace {
+				return []ctrl.Request{}
+			}
 			return []ctrl.Request{
 				{
 					NamespacedName: types.NamespacedName{

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -379,7 +379,7 @@ var _ = Describe("IPPool controller", func() {
 				ExpectRequest: false,
 			},
 		),
-		Entry("IPPool in Spec, with namespace",
+		Entry("IPPool in Spec, same namespace",
 			TestCaseM3IPCToM3IPP{
 				IPClaim: &ipamv1.IPClaim{
 					ObjectMeta: testObjectMeta,
@@ -404,6 +404,20 @@ var _ = Describe("IPPool controller", func() {
 					},
 				},
 				ExpectRequest: true,
+			},
+		),
+		Entry("IPPool in Spec, cross-namespace reference rejected",
+			TestCaseM3IPCToM3IPP{
+				IPClaim: &ipamv1.IPClaim{
+					ObjectMeta: testObjectMeta,
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "other-ns",
+						},
+					},
+				},
+				ExpectRequest: false,
 			},
 		),
 	)

--- a/internal/webhooks/v1alpha1/ipclaim_webhook.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook.go
@@ -63,6 +63,16 @@ func (webhook *IPClaim) ValidateCreate(_ context.Context, ipClaim *ipamv1.IPClai
 		)
 	}
 
+	if ipClaim.Spec.Pool.Namespace != "" && ipClaim.Spec.Pool.Namespace != ipClaim.Namespace {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "pool", "namespace"),
+				ipClaim.Spec.Pool.Namespace,
+				"must be empty or match the claim's namespace",
+			),
+		)
+	}
+
 	// Validate requested IP address if present in annotations
 	if requestedIP, ok := ipClaim.ObjectMeta.Annotations["ipAddress"]; ok && requestedIP != "" {
 		if err := validateIPAddress(ipamv1.IPAddressStr(requestedIP)); err != nil {

--- a/internal/webhooks/v1alpha1/ipclaim_webhook_test.go
+++ b/internal/webhooks/v1alpha1/ipclaim_webhook_test.go
@@ -44,6 +44,7 @@ func TestIPClaimCreateValidation(t *testing.T) {
 	tests := []struct {
 		name      string
 		claimName string
+		namespace string
 		expectErr bool
 		ipPool    corev1.ObjectReference
 	}{
@@ -51,22 +52,45 @@ func TestIPClaimCreateValidation(t *testing.T) {
 			name:      "should succeed when ipPool is correct",
 			expectErr: false,
 			claimName: "abc-1",
+			namespace: "foo",
 			ipPool: corev1.ObjectReference{
 				Name: "abc",
+			},
+		},
+		{
+			name:      "should succeed when ipPool namespace matches claim namespace",
+			expectErr: false,
+			claimName: "abc-1",
+			namespace: "foo",
+			ipPool: corev1.ObjectReference{
+				Name:      "abc",
+				Namespace: "foo",
 			},
 		},
 		{
 			name:      "should fail without ipPool",
 			expectErr: true,
 			claimName: "abc-1",
+			namespace: "foo",
 			ipPool:    corev1.ObjectReference{},
 		},
 		{
 			name:      "should fail without ipPool name",
 			expectErr: true,
 			claimName: "abc-1",
+			namespace: "foo",
 			ipPool: corev1.ObjectReference{
 				Namespace: "abc",
+			},
+		},
+		{
+			name:      "should fail when ipPool namespace differs from claim namespace",
+			expectErr: true,
+			claimName: "abc-1",
+			namespace: "foo",
+			ipPool: corev1.ObjectReference{
+				Name:      "abc",
+				Namespace: "other-namespace",
 			},
 		},
 	}
@@ -78,7 +102,7 @@ func TestIPClaimCreateValidation(t *testing.T) {
 
 			obj := &ipamv1.IPClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
+					Namespace: tt.namespace,
 					Name:      tt.claimName,
 				},
 				Spec: ipamv1.IPClaimSpec{

--- a/test/fuzz/ippool_controller_fuzz_test.go
+++ b/test/fuzz/ippool_controller_fuzz_test.go
@@ -57,7 +57,22 @@ func FuzzIPClaimToIPPool(f *testing.F) {
 			return
 		}
 
-		// Should return exactly one request when pool name is specified
+		// Determine the effective namespace
+		poolNamespace := ipClaim.Spec.Pool.Namespace
+		if poolNamespace == "" {
+			poolNamespace = ipClaim.Namespace
+		}
+
+		// Cross-namespace references must be rejected
+		if poolNamespace != ipClaim.Namespace {
+			if len(reqs) != 0 {
+				t.Errorf("expected no requests for cross-namespace pool reference (claim ns=%q, pool ns=%q), got %d",
+					ipClaim.Namespace, poolNamespace, len(reqs))
+			}
+			return
+		}
+
+		// Should return exactly one request when pool name is specified and namespace matches
 		if len(reqs) != 1 {
 			t.Errorf("expected 1 request, got %d", len(reqs))
 			return
@@ -71,14 +86,10 @@ func FuzzIPClaimToIPPool(f *testing.F) {
 				ipClaim.Spec.Pool.Name, req.NamespacedName.Name)
 		}
 
-		// Verify namespace logic
-		expectedNamespace := ipClaim.Spec.Pool.Namespace
-		if expectedNamespace == "" {
-			expectedNamespace = ipClaim.Namespace
-		}
-		if req.NamespacedName.Namespace != expectedNamespace {
+		// Verify namespace is the claim's namespace
+		if req.NamespacedName.Namespace != ipClaim.Namespace {
 			t.Errorf("namespace mismatch: expected %s, got %s",
-				expectedNamespace, req.NamespacedName.Namespace)
+				ipClaim.Namespace, req.NamespacedName.Namespace)
 		}
 	})
 }


### PR DESCRIPTION
### Problem

An IPClaim with `spec.pool.namespace` set to a different namespace than its own triggers reconciliation of an IPPool in that other namespace. While no IP allocation occurs (the pool manager only lists claims in its own namespace), the forced reconcile cycle updates the target pool's `lastUpdated` metadata.

### Fix

**Webhook validation** (`internal/webhooks/v1alpha1/ipclaim_webhook.go`):
- `ValidateCreate` now rejects IPClaims where `spec.pool.namespace` is set to a namespace different from the claim's own namespace.

**Controller validation** (`controllers/ippool_controller.go`):
- The `IPClaimToIPPool` mapper now returns an empty request when the pool namespace differs from the claim's namespace, preventing cross-namespace reconcile triggers even for pre-existing resources that bypass the webhook.

### Notes

- The CAPI `IPAddressClaim` path is unaffected, its `PoolRef` type has no  `Namespace` field and the mapper already uses the claim's own namespace.
- The `spec.pool.namespace` field cannot be deprecated because the IPClaimSpec type is using Pool corev1.ObjectReference `json:"pool"`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
