### PR TITLE
🌱 Require explicit GitHub token for release notes tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,8 +326,11 @@ release-notes-tool:
 	go build -C hack/tools -o $(BIN_DIR)/release -tags tools github.com/metal3-io/ip-address-manager/hack/tools/release
 
 .PHONY: release-notes
-release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES) release-notes-tool
-	$(TOOLS_BIN_DIR)/release --releaseTag=$(RELEASE_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
+release-notes: $(RELEASE_NOTES_DIR) $(TOOLS_DIR)/go.mod ## Generates release notes for the given tag
+	@echo "Generating release notes for $(RELEASE_TAG)..."
+	@cd $(TOOLS_DIR) && $(GO) build -tags=tools -o $(BIN_DIR)/release ./release
+	@$(TOOLS_BIN_DIR)/release --releaseTag="$(RELEASE_TAG)" --githubToken="$${GITHUB_TOKEN}" > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
+	@echo "Release notes written to $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md"
 
 .PHONY: release
 release:

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -64,7 +64,8 @@ var (
 		unknown,
 		superseded,
 	}
-	toTag = flag.String("releaseTag", "", "The tag or commit to end to.")
+	toTag       = flag.String("releaseTag", "", "The tag or commit to end to.")
+	githubToken = flag.String("githubToken", "", "The GitHub token for API access. Should have minimal scopes (e.g., public_repo or contents:read).")
 )
 
 func main() {
@@ -290,9 +291,15 @@ func formatMerge(line, prNumber string) string {
 // For minor and pre releases, it returns the main branch's latest commit.
 // For patch releases, it returns the latest commit on the corresponding release branch.
 func getCommitHashFromNewTag(newTag string) (string, error) {
-	token := os.Getenv("GITHUB_TOKEN")
+	token := *githubToken
 	if token == "" {
-		return "", errors.New("GITHUB_TOKEN is required")
+		token = os.Getenv("GITHUB_TOKEN")
+		if token != "" {
+			log.Println("WARNING: Using GITHUB_TOKEN from environment variable. Please use --githubToken flag instead for better security.")
+		}
+	}
+	if token == "" {
+		return "", errors.New("github token is required (use --githubToken flag or set GITHUB_TOKEN environment variable)")
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Harden release tool by allowing the github token to be passed explicitly via `--githubToken` flag instead of reading from the environment.

**Changes:**
- Add a `--githubToken` flag to `notes.go`, it takes precedence over the environment.
- Keep `GITHUB_TOKEN` as a fallback, with a log reminder to prefer the flag.
- Update the release-notes make target to build the tool with a -tag tools and pass `--releaseTag` and `--githubToken` explicitly.

**Improvements:**
- Makes token provisioning to the tool explicit and intentional rather than implicitly inherited from the environment.
- Documents least-privilege expectations.