### PR TITLE
🐛 Fix off-by-one in deleteOwnerRefFromList

### DIFF
--- a/ipam/utils.go
+++ b/ipam/utils.go
@@ -120,9 +120,9 @@ func deleteOwnerRefFromList(refList []metav1.OwnerReference,
 	if len(refList) == 1 {
 		return []metav1.OwnerReference{}, nil
 	}
-	refListLen := len(refList) - 1
-	refList[index] = refList[refListLen]
-	refList, err = deleteOwnerRefFromList(refList[:refListLen-1], objType, objMeta)
+	refListLastIndex := len(refList) - 1
+	refList[index] = refList[refListLastIndex]
+	refList, err = deleteOwnerRefFromList(refList[:refListLastIndex], objType, objMeta)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:RefListLen was correct so slicing with (refListLen-1) dropped two elements instead of one, which discarded an additional element.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
