### PR TITLE
🌱 Add checkPoolBonds to ValidateCreate

### DIFF
--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -71,6 +71,18 @@ func (webhook *IPPool) ValidateCreate(_ context.Context, ipPool *ipamv1.IPPool) 
 	}
 
 	allErrs := webhook.validatePoolRanges(ipPool)
+
+	allocationOutOfBonds, _ := webhook.checkPoolBonds(ipPool, ipPool)
+	for _, address := range allocationOutOfBonds {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("spec", "preAllocations"),
+				address,
+				"is out of bonds of the pools given",
+			),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil, nil
 	}

--- a/internal/webhooks/v1alpha1/ippool_webhook_test.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook_test.go
@@ -315,10 +315,30 @@ func TestIPPoolValidation(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{Subnet: &validSubnet},
+					},
 					PreAllocations: map[string]ipamv1.IPAddressStr{
 						"claim1": "192.168.0.10",
 						"claim2": "192.168.0.11",
 						"claim3": "192.168.0.12",
+					},
+				},
+			},
+		},
+		{
+			name:      "should fail when preAllocation is outside the declared pools at create",
+			expectErr: true,
+			c: &ipamv1.IPPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{Subnet: &validSubnet},
+					},
+					PreAllocations: map[string]ipamv1.IPAddressStr{
+						"claim1": "10.0.0.5",
 					},
 				},
 			},
@@ -473,6 +493,9 @@ func TestIPPoolValidation(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{Subnet: &largeV6Subnet},
+					},
 					PreAllocations: map[string]ipamv1.IPAddressStr{
 						"claim1": "2001:db8::1",
 						"claim2": "2001:db8::2",


### PR DESCRIPTION
This ensures pre-allocations are validated against declared ranges at creation time instead of only being validated after ValidateUpdate

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
