### PR TITLE
🐛 Fix propagate patch error in capiUpdateAddress 

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -385,18 +385,23 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 // Return a map where IP addresses is key and value is the associated (metal3 and/or capi) claim's name.
 func (m *IPPoolManager) capiUpdateAddress(ctx context.Context,
 	addressClaim *capipamv1.IPAddressClaim, addresses map[ipamv1.IPAddressStr]string,
-) (map[ipamv1.IPAddressStr]string, error) {
+) (_ map[ipamv1.IPAddressStr]string, rerr error) {
 	var err error
 	var helper *patch.Helper
 	helper, err = patch.NewHelper(addressClaim, m.client)
 	if err != nil {
 		return addresses, fmt.Errorf("failed to init patch helper: %w", err)
 	}
+	deleted := false
 	// Always patch addressClaim exiting this function so we can persist any changes.
 	defer func() {
-		err = helper.Patch(ctx, addressClaim)
-		if err != nil {
-			m.Log.Error(err, "failed to Patch IPAddressClaim")
+		if deleted {
+			return
+		}
+		patchErr := helper.Patch(ctx, addressClaim)
+		if patchErr != nil {
+			m.Log.Error(patchErr, "failed to Patch IPAddressClaim")
+			rerr = patchErr
 		}
 	}()
 
@@ -419,6 +424,7 @@ func (m *IPPoolManager) capiUpdateAddress(ctx context.Context,
 		if err != nil {
 			return addresses, err
 		}
+		deleted = true
 	}
 	return addresses, nil
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: The deferred patch was assigning the error to the
outer `err` variable, but this value was never returned to the caller.

Use a named return `rerr` and shadow it so the failure is not silent.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
