### PR TITLE
🐛 Reject empty pool entries in IPPool validation

### DIFF
--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -179,6 +179,10 @@ func (webhook *IPPool) isAddressInBonds(newPool *ipamv1.IPPool, address ipamv1.I
 	}
 
 	for _, pool := range newPool.Spec.Pools {
+		if pool.Start == nil && pool.End == nil && pool.Subnet == nil {
+			continue
+		}
+
 		if pool.Start != nil {
 			startIP, err := netip.ParseAddr(string(*pool.Start))
 			if err != nil {
@@ -285,6 +289,11 @@ func (webhook *IPPool) validatePoolRanges(pool *ipamv1.IPPool) field.ErrorList {
 	for i, p := range pool.Spec.Pools {
 		poolPath := field.NewPath("spec", "pools").Index(i)
 		errCountBefore := len(allErrs)
+		if p.Start == nil && p.End == nil && p.Subnet == nil {
+			allErrs = append(allErrs,
+				field.Invalid(poolPath, "", "pool entry must specify at least one of start, end, or subnet"))
+			continue
+		}
 
 		// Address-range fields (Start/End/Subnet format and start <= end) are
 		// validated by the shared api helper, so the logic is not duplicated


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:
- Empty pool entries could allow IPs in invalid ranges to be added
- Add a guard in isAddressInBonds to skip empty pool entries, and reject them in validatePoolRanges



<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
