### PR TITLE
🐛 Fix IPv4 overflow detection

### DIFF
--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -24,6 +24,15 @@ import (
 	"net"
 )
 
+const (
+	// ipv6ByteLen is the byte length of an IPv6 address.
+	ipv6ByteLen = 16
+	// Big Int value of 255.255.255.255
+	// Maximum numeric value in hex format of the IPv4-Mapped IPv6 Address
+	// according to https://www.rfc-editor.org/rfc/rfc4291.html#section-2.5.5.2
+	maxIPv4Int = 0xFFFFFFFFFFFF
+)
+
 // GetIPAddress renders the IP address, taking the index, offset and step into
 // account, it is IP version agnostic.
 func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
@@ -182,11 +191,14 @@ func lastIPInSubnet(n *net.IPNet) net.IP {
 // Note that if the resulting IP address is in the format ::ffff:xxxx:xxxx then
 // ip.String will fail to select the correct type of ip.
 func addOffsetToIP(ip, endIP net.IP, offset int) (net.IP, error) {
-	ip4 := false
-	if ip.To4() != nil {
-		ip4 = true
+	// Detect IPv4 before normalizing to 16-byte form.
+	ip4 := ip.To4() != nil
+	// Normalize to the 16-byte form so the byte-length and value checks
+	// below hold for both ParseIP and ParseCIDR inputs.
+	ip = ip.To16()
+	if ip == nil {
+		return nil, errors.New("invalid IP address")
 	}
-
 	// Create big integers.
 	IPInt := big.NewInt(0)
 	OffsetInt := big.NewInt(int64(offset))
@@ -202,9 +214,12 @@ func addOffsetToIP(ip, endIP net.IP, offset int) (net.IP, error) {
 
 	IPBytesLen := len(IPBytes)
 
-	// Verify that the IPv4 or IPv6 fulfills theirs constraints.
-	if (ip4 && IPBytesLen > 6 && IPBytes[4] != 255 && IPBytes[5] != 255) ||
-		(!ip4 && IPBytesLen > 16) {
+	// Verify that the IPv4 or IPv6 fulfills their constraints.
+	if ip4 {
+		if IPInt.Cmp(big.NewInt(maxIPv4Int)) > 0 {
+			return nil, fmt.Errorf("IP address overflow for : %s", ip.String())
+		}
+	} else if IPBytesLen > ipv6ByteLen {
 		return nil, fmt.Errorf("IP address overflow for : %s", ip.String())
 	}
 
@@ -218,7 +233,7 @@ func addOffsetToIP(ip, endIP net.IP, offset int) (net.IP, error) {
 		}
 	}
 
-	// COpy the output back into an ip.
-	copy(ip[16-IPBytesLen:], IPBytes)
+	// Copy the output back into an ip.
+	copy(ip[ipv6ByteLen-IPBytesLen:], IPBytes)
 	return ip, nil
 }

--- a/api/v1alpha1/utils_test.go
+++ b/api/v1alpha1/utils_test.go
@@ -183,6 +183,76 @@ var _ = Describe("IPPool manager", func() {
 			offset:      100,
 			expectError: true,
 		}),
+
+		Entry("IPv4 minimum address", testCaseAddOffsetToIP{
+			ip:         "0.0.0.0",
+			offset:     1,
+			expectedIP: "0.0.0.1",
+		}),
+		Entry("IPv4 maximum address no overflow", testCaseAddOffsetToIP{
+			ip:         "255.255.255.254",
+			offset:     1,
+			expectedIP: "255.255.255.255",
+		}),
+		Entry("IPv4 overflow from max address", testCaseAddOffsetToIP{
+			ip:          "255.255.255.255",
+			offset:      1,
+			expectError: true,
+		}),
+		Entry("IPv4 overflow from high address with large offset", testCaseAddOffsetToIP{
+			ip:          "255.255.255.0",
+			offset:      256,
+			expectError: true,
+		}),
+		Entry("IPv4 zero offset returns same address", testCaseAddOffsetToIP{
+			ip:         "10.0.0.1",
+			offset:     0,
+			expectedIP: "10.0.0.1",
+		}),
+
+		// IPv6 boundary tests
+		Entry("IPv6 minimum address", testCaseAddOffsetToIP{
+			ip:         "::",
+			offset:     1,
+			expectedIP: "::1",
+		}),
+		Entry("IPv6 maximum address no overflow", testCaseAddOffsetToIP{
+			ip:         "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFE",
+			offset:     1,
+			expectedIP: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+		}),
+		Entry("IPv6 overflow from max address", testCaseAddOffsetToIP{
+			ip:          "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF",
+			offset:      1,
+			expectError: true,
+		}),
+		Entry("IPv6 normal address with offset", testCaseAddOffsetToIP{
+			ip:         "2001:db8::1",
+			offset:     255,
+			expectedIP: "2001:db8::100",
+		}),
+		Entry("IPv6 zero offset returns same address", testCaseAddOffsetToIP{
+			ip:         "fe80::1",
+			offset:     0,
+			expectedIP: "fe80::1",
+		}),
+		Entry("IPv6 large address not mistaken for IPv4 overflow", testCaseAddOffsetToIP{
+			ip:         "2001:db8::ffff:ffff",
+			offset:     1,
+			expectedIP: "2001:db8::1:0:0",
+		}),
+		Entry("IPv6 with end IP within bounds", testCaseAddOffsetToIP{
+			ip:         "2001:db8::1",
+			endIP:      "2001:db8::ff",
+			offset:     10,
+			expectedIP: "2001:db8::b",
+		}),
+		Entry("IPv6 with end IP out of bounds", testCaseAddOffsetToIP{
+			ip:          "2001:db8::1",
+			endIP:       "2001:db8::ff",
+			offset:      1000,
+			expectError: true,
+		}),
 	)
 
 	type testCaseGetPoolSize struct {


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: The overflow check used byte-length and
fixed index checks (IPBytes[4], IPBytes[5]). This was unreliable

Replace with a direct comparison against the maximum IPv4 address.
Replaced magic number with a constant to represent byte length for linter

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
