### PR TITLE
🐛 Clear stale address reference when IPAddress is deleted

### DIFF
--- a/controllers/ippool_controller.go
+++ b/controllers/ippool_controller.go
@@ -196,6 +196,13 @@ func (r *IPPoolReconciler) SetupWithManagerForIPClaim(ctx context.Context, mgr c
 			&ipamv1.IPClaim{},
 			handler.EnqueueRequestsFromMapFunc(r.IPClaimToIPPool),
 		).
+		// Watch IPAddresses so that deleting one (which leaves a stale
+		// reference on its IPClaim) triggers a reconcile of the owning IPPool
+		// to re-allocate a replacement.
+		Watches(
+			&ipamv1.IPAddress{},
+			handler.EnqueueRequestsFromMapFunc(r.IPAddressToIPPool),
+		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 }
@@ -209,6 +216,12 @@ func (r *IPPoolReconciler) SetupWithManagerForIPAddressClaim(ctx context.Context
 		Watches(
 			&capipamv1.IPAddressClaim{},
 			handler.EnqueueRequestsFromMapFunc(r.IPAddressClaimToIPPool),
+		).
+		// Watch CAPI IPAddresses so that deleting one triggers a reconcile of
+		// the owning IPPool to re-allocate a replacement.
+		Watches(
+			&capipamv1.IPAddress{},
+			handler.EnqueueRequestsFromMapFunc(r.CAPIIPAddressToIPPool),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
@@ -246,6 +259,52 @@ func (r *IPPoolReconciler) IPAddressClaimToIPPool(_ context.Context, obj client.
 					NamespacedName: types.NamespacedName{
 						Name:      ipac.Spec.PoolRef.Name,
 						Namespace: namespace,
+					},
+				},
+			}
+		}
+	}
+	return []ctrl.Request{}
+}
+
+// IPAddressToIPPool maps a metal3 IPAddress event (including deletion) to a
+// reconcile request for the IPPool that owns it, so a deleted IPAddress causes
+// the pool to re-allocate a replacement for the affected claim.
+func (r *IPPoolReconciler) IPAddressToIPPool(_ context.Context, obj client.Object) []ctrl.Request {
+	if ipa, ok := obj.(*ipamv1.IPAddress); ok {
+		if ipa.Spec.Pool.Name != "" {
+			namespace := ipa.Spec.Pool.Namespace
+			if namespace == "" {
+				namespace = ipa.Namespace
+			}
+			return []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      ipa.Spec.Pool.Name,
+						Namespace: namespace,
+					},
+				},
+			}
+		}
+	}
+	return []ctrl.Request{}
+}
+
+// CAPIIPAddressToIPPool maps a CAPI IPAddress event (including deletion) to a
+// reconcile request for the IPPool that owns it. The PoolRef namespace is taken
+// from the IPAddress namespace (CAPI references are always local). Events whose
+// PoolRef points at another IPAM provider are ignored so a foreign address does
+// not reconcile a same-named Metal3 IPPool.
+func (r *IPPoolReconciler) CAPIIPAddressToIPPool(_ context.Context, obj client.Object) []ctrl.Request {
+	if ipa, ok := obj.(*capipamv1.IPAddress); ok {
+		poolRef := ipa.Spec.PoolRef
+		if poolRef.Name != "" && poolRef.APIGroup == ipamv1.GroupVersion.Group &&
+			(poolRef.Kind == "" || poolRef.Kind == "IPPool") {
+			return []ctrl.Request{
+				{
+					NamespacedName: types.NamespacedName{
+						Name:      poolRef.Name,
+						Namespace: ipa.Namespace,
 					},
 				},
 			}

--- a/controllers/ippool_controller_test.go
+++ b/controllers/ippool_controller_test.go
@@ -466,4 +466,148 @@ var _ = Describe("IPPool controller", func() {
 			},
 		),
 	)
+
+	type TestCaseM3IPAToM3IPP struct {
+		IPAddress     *ipamv1.IPAddress
+		ExpectRequest bool
+	}
+
+	DescribeTable("IPAddress To IPPool tests",
+		func(tc TestCaseM3IPAToM3IPP) {
+			r := IPPoolReconciler{}
+			obj := client.Object(tc.IPAddress)
+			reqs := r.IPAddressToIPPool(context.Background(), obj)
+
+			if tc.ExpectRequest {
+				Expect(reqs).To(HaveLen(1), "Expected 1 request, found %d", len(reqs))
+
+				req := reqs[0]
+				Expect(req.NamespacedName.Name).To(Equal(tc.IPAddress.Spec.Pool.Name),
+					"Expected name %s, found %s", tc.IPAddress.Spec.Pool.Name, req.NamespacedName.Name)
+				if tc.IPAddress.Spec.Pool.Namespace == "" {
+					Expect(req.NamespacedName.Namespace).To(Equal(tc.IPAddress.Namespace),
+						"Expected namespace %s, found %s", tc.IPAddress.Namespace, req.NamespacedName.Namespace)
+				} else {
+					Expect(req.NamespacedName.Namespace).To(Equal(tc.IPAddress.Spec.Pool.Namespace),
+						"Expected namespace %s, found %s", tc.IPAddress.Spec.Pool.Namespace, req.NamespacedName.Namespace)
+				}
+			} else {
+				Expect(reqs).To(BeEmpty(), "Expected 0 request, found %d", len(reqs))
+			}
+		},
+		Entry("No IPPool in Spec",
+			TestCaseM3IPAToM3IPP{
+				IPAddress: &ipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec:       ipamv1.IPAddressSpec{},
+				},
+				ExpectRequest: false,
+			},
+		),
+		Entry("IPPool in Spec, with namespace",
+			TestCaseM3IPAToM3IPP{
+				IPAddress: &ipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+		Entry("IPPool in Spec, no namespace",
+			TestCaseM3IPAToM3IPP{
+				IPAddress: &ipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec: ipamv1.IPAddressSpec{
+						Pool: corev1.ObjectReference{
+							Name: "abc",
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+	)
+
+	type TestCaseK8SIPAToM3IPP struct {
+		IPAddress     *capipamv1.IPAddress
+		ExpectRequest bool
+	}
+
+	DescribeTable("CAPI IPAddress To IPPool tests",
+		func(tc TestCaseK8SIPAToM3IPP) {
+			r := IPPoolReconciler{}
+			obj := client.Object(tc.IPAddress)
+			reqs := r.CAPIIPAddressToIPPool(context.Background(), obj)
+
+			if tc.ExpectRequest {
+				Expect(reqs).To(HaveLen(1), "Expected 1 request, found %d", len(reqs))
+
+				req := reqs[0]
+				Expect(req.NamespacedName.Name).To(Equal(tc.IPAddress.Spec.PoolRef.Name),
+					"Expected name %s, found %s", tc.IPAddress.Spec.PoolRef.Name, req.NamespacedName.Name)
+				Expect(req.NamespacedName.Namespace).To(Equal(tc.IPAddress.Namespace),
+					"Expected namespace %s, found %s", tc.IPAddress.Namespace, req.NamespacedName.Namespace)
+			} else {
+				Expect(reqs).To(BeEmpty(), "Expected 0 request, found %d", len(reqs))
+			}
+		},
+		Entry("No IPPool in Spec",
+			TestCaseK8SIPAToM3IPP{
+				IPAddress: &capipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec:       capipamv1.IPAddressSpec{},
+				},
+				ExpectRequest: false,
+			},
+		),
+		Entry("Metal3 IPPool in Spec",
+			TestCaseK8SIPAToM3IPP{
+				IPAddress: &capipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     "abc",
+							Kind:     "IPPool",
+							APIGroup: ipamv1.GroupVersion.Group,
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+		Entry("Metal3 IPPool in Spec, empty kind",
+			TestCaseK8SIPAToM3IPP{
+				IPAddress: &capipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     "abc",
+							APIGroup: ipamv1.GroupVersion.Group,
+						},
+					},
+				},
+				ExpectRequest: true,
+			},
+		),
+		Entry("Foreign provider IPPool in Spec is ignored",
+			TestCaseK8SIPAToM3IPP{
+				IPAddress: &capipamv1.IPAddress{
+					ObjectMeta: testObjectMeta,
+					Spec: capipamv1.IPAddressSpec{
+						PoolRef: capipamv1.IPPoolReference{
+							Name:     "abc",
+							Kind:     "InClusterIPPool",
+							APIGroup: "ipam.cluster.x-k8s.io",
+						},
+					},
+				},
+				ExpectRequest: false,
+			},
+		),
+	)
 })

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -274,7 +274,21 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 		}
 
 		if addressClaim.Status.Address != nil && addressClaim.DeletionTimestamp.IsZero() {
-			continue
+			// Verify the referenced IPAddress still exists before skipping.
+			existingAddr := &ipamv1.IPAddress{}
+			key := client.ObjectKey{
+				Name:      addressClaim.Status.Address.Name,
+				Namespace: m.IPPool.Namespace,
+			}
+			getErr := m.client.Get(ctx, key, existingAddr)
+			if getErr == nil {
+				continue
+			}
+			if !apierrors.IsNotFound(getErr) {
+				return 0, getErr
+			}
+			// IPAddress is gone: clear stale reference and fall through to re-allocate.
+			addressClaim.Status.Address = nil
 		}
 
 		if addressClaim.Status.ErrorMessage != nil && addressClaim.DeletionTimestamp.IsZero() {
@@ -315,7 +329,21 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 		}
 
 		if addressClaim.Status.AddressRef.Name != "" && addressClaim.DeletionTimestamp.IsZero() {
-			continue
+			// Verify the referenced IPAddress still exists before skipping.
+			existingAddr := &capipamv1.IPAddress{}
+			key := client.ObjectKey{
+				Name:      addressClaim.Status.AddressRef.Name,
+				Namespace: m.IPPool.Namespace,
+			}
+			getErr := m.client.Get(ctx, key, existingAddr)
+			if getErr == nil {
+				continue
+			}
+			if !apierrors.IsNotFound(getErr) {
+				return 0, getErr
+			}
+			// IPAddress is gone: clear stale reference and fall through to re-allocate.
+			addressClaim.Status.AddressRef = capipamv1.IPAddressReference{}
 		}
 
 		if anyErrorInExistingClaim(addressClaim) && addressClaim.DeletionTimestamp.IsZero() {

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -245,6 +245,13 @@ func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// refNamespaceMatches reports whether an ObjectReference namespace refers to
+// the given namespace. An empty reference namespace is a valid local reference
+// and is treated as the current namespace.
+func refNamespaceMatches(refNamespace, namespace string) bool {
+	return refNamespace == "" || refNamespace == namespace
+}
+
 // UpdateM3Addresses manages the ipclaims.ipam.metal3.io and creates or deletes IPAddress.ipam.metal3.io accordingly.
 // It returns the number of current allocations. Current allocation include
 // both capi and metal3 type ipaddress objects.
@@ -274,7 +281,29 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 		}
 
 		if addressClaim.Status.Address != nil && addressClaim.DeletionTimestamp.IsZero() {
-			continue
+			existingAddr := &ipamv1.IPAddress{}
+			key := client.ObjectKey{
+				Name:      addressClaim.Status.Address.Name,
+				Namespace: m.IPPool.Namespace,
+			}
+			getErr := m.client.Get(ctx, key, existingAddr)
+			// Skip only if the address exists, is not being deleted, and still
+			// belongs to this claim and pool. The status reference must also be
+			// local (empty or this namespace): the lookup is scoped to the pool
+			// namespace, so a status reference naming another namespace must not
+			// be treated as satisfied. An empty reference namespace is a valid
+			// local reference.
+			if getErr == nil && existingAddr.DeletionTimestamp.IsZero() &&
+				refNamespaceMatches(addressClaim.Status.Address.Namespace, addressClaim.Namespace) &&
+				existingAddr.Spec.Claim.Name == addressClaim.Name &&
+				refNamespaceMatches(existingAddr.Spec.Claim.Namespace, addressClaim.Namespace) &&
+				existingAddr.Spec.Pool.Name == m.IPPool.Name &&
+				refNamespaceMatches(existingAddr.Spec.Pool.Namespace, m.IPPool.Namespace) {
+				continue
+			}
+			if getErr != nil && !apierrors.IsNotFound(getErr) {
+				return 0, getErr
+			}
 		}
 
 		if addressClaim.Status.ErrorMessage != nil && addressClaim.DeletionTimestamp.IsZero() {
@@ -315,7 +344,24 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 		}
 
 		if addressClaim.Status.AddressRef.Name != "" && addressClaim.DeletionTimestamp.IsZero() {
-			continue
+			existingAddr := &capipamv1.IPAddress{}
+			key := client.ObjectKey{
+				Name:      addressClaim.Status.AddressRef.Name,
+				Namespace: m.IPPool.Namespace,
+			}
+			getErr := m.client.Get(ctx, key, existingAddr)
+			// Skip only if the address exists, is not being deleted, and still
+			// belongs to this claim and pool. CAPI claim/pool references are
+			// name-only and always resolve within this namespace, so there are
+			// no namespaces to compare here.
+			if getErr == nil && existingAddr.DeletionTimestamp.IsZero() &&
+				existingAddr.Spec.ClaimRef.Name == addressClaim.Name &&
+				existingAddr.Spec.PoolRef.Name == m.IPPool.Name {
+				continue
+			}
+			if getErr != nil && !apierrors.IsNotFound(getErr) {
+				return 0, getErr
+			}
 		}
 
 		if anyErrorInExistingClaim(addressClaim) && addressClaim.DeletionTimestamp.IsZero() {
@@ -357,6 +403,11 @@ func (m *IPPoolManager) updateAddress(ctx context.Context,
 	addressClaim.Status.ErrorMessage = nil
 
 	if addressClaim.DeletionTimestamp.IsZero() {
+		// Clear any address reference before re-allocating. The patch helper
+		// above tracks this, so a dangling reference (an IPAddress that no
+		// longer exists) is removed even if createAddress fails. On success,
+		// createAddress sets the reference to the freshly allocated address.
+		addressClaim.Status.Address = nil
 		addresses, err = m.createAddress(ctx, addressClaim, addresses)
 		if err != nil {
 			return addresses, err
@@ -406,6 +457,12 @@ func (m *IPPoolManager) capiUpdateAddress(ctx context.Context,
 	}()
 
 	if addressClaim.DeletionTimestamp.IsZero() {
+		// Clear any address reference before re-allocating. The patch helper
+		// above tracks this, so a dangling reference (an IPAddress that no
+		// longer exists) is removed even if capiCreateAddress fails. On
+		// success, capiCreateAddress sets the reference to the freshly
+		// allocated address.
+		addressClaim.Status.AddressRef = capipamv1.IPAddressReference{}
 		addresses, err = m.capiCreateAddress(ctx, addressClaim, addresses)
 		if err != nil {
 			return addresses, err

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 
 	"github.com/go-logr/logr"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
@@ -672,6 +673,13 @@ var _ = Describe("IPPool manager", func() {
 		expectError           bool
 		expectedNbAllocations int
 		expectedAllocations   map[string]ipamv1.IPAddressStr
+		// Names of IPClaims whose Status.Address must be nil (cleared) after
+		// the reconcile, e.g. a dangling reference that could not be
+		// re-allocated.
+		expectClearedM3Claims []string
+		// Names of CAPI IPAddressClaims whose Status.AddressRef must be empty
+		// (cleared) after the reconcile.
+		expectClearedCAPIClaims []string
 	}
 
 	DescribeTable("Test UpdateAddresses",
@@ -722,8 +730,21 @@ var _ = Describe("IPPool manager", func() {
 
 			// Iterate over the IPAddress objects to find all indexes and objects
 			for _, claim := range addressObjects.Items {
+				// Claims whose stale reference was intentionally cleared (and
+				// could not be re-allocated) are checked separately below.
+				if slices.Contains(tc.expectClearedM3Claims, claim.Name) {
+					continue
+				}
 				if claim.DeletionTimestamp.IsZero() && claim.Status.ErrorMessage == nil {
 					Expect(claim.Status.Address).NotTo(BeNil())
+					// The persisted claim status must reference an IPAddress
+					// object that actually exists in the cluster.
+					existingAddr := &ipamv1.IPAddress{}
+					err = c.Get(context.TODO(), client.ObjectKey{
+						Name:      claim.Status.Address.Name,
+						Namespace: tc.ipPool.Namespace,
+					}, existingAddr)
+					Expect(err).NotTo(HaveOccurred())
 				}
 			}
 
@@ -734,9 +755,44 @@ var _ = Describe("IPPool manager", func() {
 
 			// Iterate over the IPAddress objects to find all indexes and objects
 			for _, claim := range capiAddressObjects.Items {
+				// Claims whose stale reference was intentionally cleared (and
+				// could not be re-allocated) are checked separately below.
+				if slices.Contains(tc.expectClearedCAPIClaims, claim.Name) {
+					continue
+				}
 				if claim.DeletionTimestamp.IsZero() && !anyErrorInExistingClaim(claim) {
 					Expect(claim.Status.AddressRef).NotTo(BeNil())
+					Expect(claim.Status.AddressRef.Name).NotTo(BeEmpty())
+					// The persisted claim status must reference an IPAddress
+					// object that actually exists.
+					existingAddr := &capipamv1.IPAddress{}
+					err = c.Get(context.TODO(), client.ObjectKey{
+						Name:      claim.Status.AddressRef.Name,
+						Namespace: tc.ipPool.Namespace,
+					}, existingAddr)
+					Expect(err).NotTo(HaveOccurred())
 				}
+			}
+
+			// Verify that dangling references were cleared and persisted, even
+			// for claims where re-allocation could not complete.
+			for _, name := range tc.expectClearedM3Claims {
+				claim := &ipamv1.IPClaim{}
+				err = c.Get(context.TODO(), client.ObjectKey{
+					Name:      name,
+					Namespace: tc.ipPool.Namespace,
+				}, claim)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(claim.Status.Address).To(BeNil())
+			}
+			for _, name := range tc.expectClearedCAPIClaims {
+				claim := &capipamv1.IPAddressClaim{}
+				err = c.Get(context.TODO(), client.ObjectKey{
+					Name:      name,
+					Namespace: tc.ipPool.Namespace,
+				}, claim)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(claim.Status.AddressRef.Name).To(BeEmpty())
 			}
 
 		},
@@ -1631,6 +1687,166 @@ var _ = Describe("IPPool manager", func() {
 				},
 			},
 			expectedNbAllocations: 3,
+		}),
+		Entry("IPClaim with stale Status.Address and missing IPAddress is re-allocated", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:     24,
+					Gateway:    (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipClaims: []*ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+					// Points to an IPAddress that does not exist. The manager
+					// must clear this stale reference and re-allocate.
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-0-99",
+							Namespace: "myns",
+						},
+					},
+				},
+			},
+			// No IPAddress objects exist, so the stale reference is dangling.
+			ipAddresses:           []*ipamv1.IPAddress{},
+			expectedNbAllocations: 1,
+		}),
+		Entry("CAPI IPAddressClaim with stale AddressRef and missing IPAddress is re-allocated", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					Pools: []ipamv1.Pool{
+						{
+							Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+							End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+						},
+					},
+					Prefix:     24,
+					Gateway:    (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *capiPoolRef,
+					},
+					// Points to an IPAddress that does not exist. The manager
+					// must clear this stale reference and re-allocate.
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: capipamv1.IPAddressReference{
+							Name: "abcpref-192-168-0-99",
+						},
+					},
+				},
+			},
+			// No CAPI IPAddress objects exist, so the stale reference is dangling.
+			capiAddresses:         []*capipamv1.IPAddress{},
+			expectedNbAllocations: 1,
+		}),
+		Entry("IPClaim with stale Status.Address has it cleared even when re-allocation fails", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					// No pools, so re-allocation cannot succeed (exhausted).
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipClaims: []*ipamv1.IPClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: ipamv1.IPClaimSpec{
+						Pool: corev1.ObjectReference{
+							Name:      "abc",
+							Namespace: "myns",
+						},
+					},
+					// Dangling reference: the IPAddress does not exist.
+					Status: ipamv1.IPClaimStatus{
+						Address: &corev1.ObjectReference{
+							Name:      "abcpref-192-168-0-99",
+							Namespace: "myns",
+						},
+					},
+				},
+			},
+			ipAddresses:           []*ipamv1.IPAddress{},
+			expectError:           true,
+			expectedNbAllocations: 0,
+			expectedAllocations:   map[string]ipamv1.IPAddressStr{},
+			// The stale reference must be cleared and persisted despite the
+			// allocation failure, so the claim is not stuck on later reconciles.
+			expectClearedM3Claims: []string{"abc"},
+		}),
+		Entry("CAPI IPAddressClaim with stale AddressRef has it cleared even when re-allocation fails", testCaseUpdateAddresses{
+			ipPool: &ipamv1.IPPool{
+				ObjectMeta: ipPoolMeta,
+				Spec: ipamv1.IPPoolSpec{
+					// No pools, so re-allocation cannot succeed (exhausted).
+					NamePrefix: "abcpref",
+				},
+				Status: ipamv1.IPPoolStatus{
+					Allocations: map[string]ipamv1.IPAddressStr{},
+				},
+			},
+			ipAddressClaims: []*capipamv1.IPAddressClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+					Spec: capipamv1.IPAddressClaimSpec{
+						PoolRef: *capiPoolRef,
+					},
+					// Dangling reference: the IPAddress does not exist.
+					Status: capipamv1.IPAddressClaimStatus{
+						AddressRef: capipamv1.IPAddressReference{
+							Name: "abcpref-192-168-0-99",
+						},
+					},
+				},
+			},
+			capiAddresses:         []*capipamv1.IPAddress{},
+			expectError:           true,
+			expectedNbAllocations: 0,
+			expectedAllocations:   map[string]ipamv1.IPAddressStr{},
+			// The stale reference must be cleared and persisted despite the
+			// allocation failure.
+			expectClearedCAPIClaims: []string{"abc"},
 		}),
 	)
 


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: 

When an IPAddress object is deleted, the corresponding IPClaim retains a
Status.Address reference to the object. The reconciler's skip condition
trusts this reference and bypasses the claim, preventing re-allocation.

Before skipping, look up the referenced IPAddress. Only skip the claim if
that address exists, is not being deleted, and still belongs to this claim
and pool.  Otherwise fall through to
updateAddress, which re-allocates a replacement. 
Add a watch on IPAddress objects that maps an event, including deletion,
back to the owning IPPool, so a deleted IPAddress triggers reconciliation
and re-allocation instead of waiting for an unrelated event.

Apply the same fix to both the metal3 IPClaim / IPAddress path and the
CAPI IPAddressClaim / IPAddress path.

Add unit tests for the recovery paths and the IPAddress-to-IPPool mappers.



<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
