### PR TITLE
🌱 Enforce immutability of ipAddress annotation on update

### DIFF
--- a/internal/webhooks/v1alpha1/ipaddress_webhook.go
+++ b/internal/webhooks/v1alpha1/ipaddress_webhook.go
@@ -156,6 +156,16 @@ func (webhook *IPAddress) ValidateUpdate(_ context.Context, oldIPAddress, newIPA
 		)
 	}
 
+	if newIPAddress.Annotations["ipAddress"] != oldIPAddress.Annotations["ipAddress"] {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("metadata", "annotations", "ipAddress"),
+				newIPAddress.Annotations["ipAddress"],
+				"cannot be modified",
+			),
+		)
+	}
+
 	if newIPAddress.Spec.Claim.Name != oldIPAddress.Spec.Claim.Name {
 		allErrs = append(allErrs,
 			field.Invalid(


### PR DESCRIPTION

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Enforce immutability by rejecting changes to the annotation on update.

ValidateCreate validates the ipAddress annotation format, but ValidateUpdate did not.


<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
