### PR TITLE
🐛 Share addresses map across metal3 and CAPI allocation phases

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -234,26 +234,24 @@ func (m *IPPoolManager) UpdateAddresses(ctx context.Context) (int, error) {
 	if m.IPPool.Status.LastUpdated == nil {
 		m.IPPool.Status.LastUpdated = m.IPPool.CreationTimestamp.DeepCopy()
 	}
-	_, err := m.m3UpdateAddresses(ctx)
-	if err != nil {
-		return 0, err
-	}
-	count, err := m.capiUpdateAddresses(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
-// UpdateM3Addresses manages the ipclaims.ipam.metal3.io and creates or deletes IPAddress.ipam.metal3.io accordingly.
-// It returns the number of current allocations. Current allocation include
-// both capi and metal3 type ipaddress objects.
-func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 	addresses, err := m.getIndexes(ctx)
 	if err != nil {
 		return 0, err
 	}
+	addresses, err = m.m3UpdateAddresses(ctx, addresses)
+	if err != nil {
+		return 0, err
+	}
+	addresses, err = m.capiUpdateAddresses(ctx, addresses)
+	if err != nil {
+		return 0, err
+	}
+	return len(addresses), nil
+}
 
+// UpdateM3Addresses manages the ipclaims.ipam.metal3.io and creates or deletes IPAddress.ipam.metal3.io accordingly.
+// It returns the updated addresses map.
+func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context, addresses map[ipamv1.IPAddressStr]string) (map[ipamv1.IPAddressStr]string, error) {
 	// get list of IPClaim objects
 	addressClaimObjects := ipamv1.IPClaimList{}
 	// without this ListOption, all namespaces would be including in the listing
@@ -261,9 +259,9 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 		Namespace: m.IPPool.Namespace,
 	}
 
-	err = m.client.List(ctx, &addressClaimObjects, opts)
+	err := m.client.List(ctx, &addressClaimObjects, opts)
 	if err != nil {
-		return 0, err
+		return addresses, err
 	}
 
 	// Iterate over the IPClaim objects to find all addresses and objects
@@ -282,19 +280,15 @@ func (m *IPPoolManager) m3UpdateAddresses(ctx context.Context) (int, error) {
 		}
 		addresses, err = m.updateAddress(ctx, &addressClaim, addresses)
 		if err != nil {
-			return 0, err
+			return addresses, err
 		}
 	}
-	return len(addresses), nil
+	return addresses, nil
 }
 
 // UpdateCAPIAddresses manages the ipaddressclaims.ipam.cluster.x-k8s.io and creates or deletes IPAddress.ipam.cluster.x-k8s.io accordingly.
-// It returns the number of current allocations.
-func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
-	addresses, err := m.getIndexes(ctx)
-	if err != nil {
-		return 0, err
-	}
+// It returns the updated addresses map.
+func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context, addresses map[ipamv1.IPAddressStr]string) (map[ipamv1.IPAddressStr]string, error) {
 	// get list of IPClaim objects
 	addressClaimObjects := capipamv1.IPAddressClaimList{}
 	// without this ListOption, all namespaces would be including in the listing
@@ -302,9 +296,9 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 		Namespace: m.IPPool.Namespace,
 	}
 
-	err = m.client.List(ctx, &addressClaimObjects, opts)
+	err := m.client.List(ctx, &addressClaimObjects, opts)
 	if err != nil {
-		return 0, err
+		return addresses, err
 	}
 
 	// Iterate over the IPAddressClaim objects to find all addresses and objects
@@ -323,10 +317,10 @@ func (m *IPPoolManager) capiUpdateAddresses(ctx context.Context) (int, error) {
 		}
 		addresses, err = m.capiUpdateAddress(ctx, &addressClaim, addresses)
 		if err != nil {
-			return 0, err
+			return addresses, err
 		}
 	}
-	return len(addresses), nil
+	return addresses, nil
 }
 
 // UpdateAddress creates metal3 ipaddress or deletes it. Address can be deleted if it

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -1634,6 +1634,78 @@ var _ = Describe("IPPool manager", func() {
 		}),
 	)
 
+	It("UpdateAddresses does not reuse an address when the metal3 IPAddress create is not yet visible to a list", func() {
+		ipPool := &ipamv1.IPPool{
+			ObjectMeta: ipPoolMeta,
+			Spec: ipamv1.IPPoolSpec{
+				Pools: []ipamv1.Pool{
+					{
+						Start: (*ipamv1.IPAddressStr)(ptr.To("192.168.0.11")),
+						End:   (*ipamv1.IPAddressStr)(ptr.To("192.168.0.20")),
+					},
+				},
+				Prefix:     24,
+				Gateway:    (*ipamv1.IPAddressStr)(ptr.To("192.168.0.1")),
+				NamePrefix: "abcpref",
+			},
+		}
+		objects := []client.Object{
+			&ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "m3claim",
+					Namespace: "myns",
+				},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{
+						Name:      "abc",
+						Namespace: "myns",
+					},
+				},
+			},
+			&capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "capiclaim",
+					Namespace: "myns",
+				},
+				Spec: capipamv1.IPAddressClaimSpec{
+					PoolRef: *capiPoolRef,
+				},
+			},
+		}
+		fakeClient := fakeclient.NewClientBuilder().WithScheme(setupScheme()).
+			WithStatusSubresource(objects...).WithObjects(objects...).Build()
+		c := &staleAddressListClient{Client: fakeClient, listCounts: map[string]int{}}
+
+		ipPoolMgr, err := NewIPPoolManager(c, ipPool, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		nbAllocations, err := ipPoolMgr.UpdateAddresses(context.TODO())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nbAllocations).To(Equal(2))
+		Expect(ipPool.Status.Allocations).To(Equal(map[string]ipamv1.IPAddressStr{
+			"m3claim":   ipamv1.IPAddressStr("192.168.0.11"),
+			"capiclaim": ipamv1.IPAddressStr("192.168.0.12"),
+		}))
+
+		// The indexes are fetched once for the whole reconciliation, so the
+		// stale list cannot be observed a second time.
+		Expect(c.listCounts[fmt.Sprintf("%T", &ipamv1.IPAddressList{})]).To(Equal(1))
+		Expect(c.listCounts[fmt.Sprintf("%T", &capipamv1.IPAddressList{})]).To(Equal(1))
+
+		// Distinct IPAddress objects were persisted, one per phase.
+		m3Address := &ipamv1.IPAddress{}
+		Expect(fakeClient.Get(context.TODO(), client.ObjectKey{
+			Name: "abcpref-192-168-0-11", Namespace: "myns",
+		}, m3Address)).To(Succeed())
+		Expect(m3Address.Spec.Claim.Name).To(Equal("m3claim"))
+
+		capiAddress := &capipamv1.IPAddress{}
+		Expect(fakeClient.Get(context.TODO(), client.ObjectKey{
+			Name: "abcpref-192-168-0-12", Namespace: "myns",
+		}, capiAddress)).To(Succeed())
+		Expect(capiAddress.Spec.ClaimRef.Name).To(Equal("capiclaim"))
+	})
+
 	type testCaseCreateAddresses struct {
 		ipPool              *ipamv1.IPPool
 		ipClaim             *ipamv1.IPClaim
@@ -3610,3 +3682,20 @@ var _ = Describe("IPPool manager", func() {
 	})
 
 })
+
+// staleAddressListClient simulates an informer cache that has not caught up
+// with freshly created metal3 IPAddress objects: listing them never returns
+// anything. It also counts the lists performed per list type, so tests can
+// assert how often the address indexes are fetched.
+type staleAddressListClient struct {
+	client.Client
+	listCounts map[string]int
+}
+
+func (c *staleAddressListClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.listCounts[fmt.Sprintf("%T", list)]++
+	if _, ok := list.(*ipamv1.IPAddressList); ok {
+		return nil
+	}
+	return c.Client.List(ctx, list, opts...)
+}


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Call getIndexes once in UpdateAddresses and pass the resulting map to m3UpdateAddresses and capiUpdateAddresses. Each allocation updates the shared map in place, so the CAPI phase sees IPs committed by the metal3 phase regardless of cache propagation delay.

Closes a window for duplicate IP allocation.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
