### PR TITLE
🌱 Clean up osv-scanner config file on interrupted exit

### DIFF
--- a/hack/verify-release.sh
+++ b/hack/verify-release.sh
@@ -164,9 +164,11 @@ fi
 cleanup()
 {
     rm -rf "${TMP_DIR}"
+    rm -f "${CONFIG_FILE}"
 }
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/verify-release-XXXXX")"
+CONFIG_FILE=".osv-scanner.toml"
 RELEASE_JSON="${TMP_DIR}/release.json"
 RELEASES_JSON="${TMP_DIR}/releases.json"
 SCAN_LOG="${TMP_DIR}/scan.log"
@@ -621,21 +623,21 @@ verify_module_releases()
 verify_vulnerabilities()
 {
     # run osv-scanner to verify if we have open vulnerabilities in deps
-    local go_version config_file=".osv-scanner.toml"
+    local go_version
 
     echo "Verifying vulnerabilities ..."
 
     go_version="$(make go-version)"
-    echo "GoVersionOverride = \"${go_version}\"" > "${config_file}"
+    echo "GoVersionOverride = \"${go_version}\"" > "${CONFIG_FILE}"
     "${OSVSCANNER_CMD[@]}" scan \
         --recursive \
-        --config="${config_file}" \
+        --config="${CONFIG_FILE}" \
         ./ > "${SCAN_LOG}" || true
 
     if ! grep -q "No vulnerabilities found" "${SCAN_LOG}"; then
         cat "${SCAN_LOG}"
     fi
-    rm -f "${config_file}"
+    rm -f "${CONFIG_FILE}"
 
     echo -e "Done\n"
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: Make the config file path a global variable and add it to the cleanup() trap so it is removed on any exit path.

verify_vulnerabilities wrote .osv-scanner.toml to the repo root and removed it at the end of the function. If the script exited early the in-function rm was never reached and the file was left behind.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes # 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
