### PR TITLE
🌱 Fix spelling by changing bond to bound

### DIFF
--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -53,7 +53,7 @@ func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
 				return "", err
 			}
 			if !ipNet.Contains(ip) {
-				return "", errors.New("IP address out of bonds")
+				return "", errors.New("IP address out of bounds")
 			}
 		}
 
@@ -71,7 +71,7 @@ func GetIPAddress(entry Pool, index int) (IPAddressStr, error) {
 
 		// Verify that the ip is in the subnet.
 		if !ipNet.Contains(ip) {
-			return "", errors.New("IP address out of bonds")
+			return "", errors.New("IP address out of bounds")
 		}
 	}
 	return IPAddressStr(ip.String()), nil
@@ -214,7 +214,7 @@ func addOffsetToIP(ip, endIP net.IP, offset int) (net.IP, error) {
 		endIPInt = endIPInt.SetBytes(endIP)
 		// Computed IP is higher than the end IP.
 		if IPInt.Cmp(endIPInt) > 0 {
-			return nil, fmt.Errorf("IP address out of bonds for : %s", ip.String())
+			return nil, fmt.Errorf("IP address out of bounds for : %s", ip.String())
 		}
 	}
 

--- a/internal/webhooks/v1alpha1/ippool_webhook.go
+++ b/internal/webhooks/v1alpha1/ippool_webhook.go
@@ -72,7 +72,7 @@ func (webhook *IPPool) ValidateCreate(_ context.Context, ipPool *ipamv1.IPPool) 
 
 	allErrs := webhook.validatePoolRanges(ipPool)
 
-	allocationOutOfBonds, _ := webhook.checkPoolBonds(ipPool, ipPool)
+	allocationOutOfBonds, _ := webhook.checkPoolBounds(ipPool, ipPool)
 	for _, address := range allocationOutOfBonds {
 		allErrs = append(allErrs,
 			field.Invalid(
@@ -134,25 +134,25 @@ func (webhook *IPPool) ValidateUpdate(_ context.Context, oldIPPool, newIPPool *i
 	// Validate the new pool ranges
 	allErrs = append(allErrs, webhook.validatePoolRanges(newIPPool)...)
 
-	allocationOutOfBonds, inUseOutOfBonds := webhook.checkPoolBonds(oldIPPool, newIPPool)
-	if len(allocationOutOfBonds) != 0 {
-		for _, address := range allocationOutOfBonds {
+	allocationOutOfBounds, inUseOutOfBounds := webhook.checkPoolBounds(oldIPPool, newIPPool)
+	if len(allocationOutOfBounds) != 0 {
+		for _, address := range allocationOutOfBounds {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec", "preAllocations"),
 					address,
-					"is out of bonds of the pools given",
+					"is out of bounds of the pools given",
 				),
 			)
 		}
 	}
-	if len(inUseOutOfBonds) != 0 {
-		for _, address := range inUseOutOfBonds {
+	if len(inUseOutOfBounds) != 0 {
+		for _, address := range inUseOutOfBounds {
 			allErrs = append(allErrs,
 				field.Invalid(
 					field.NewPath("spec", "pools"),
 					address,
-					"is in use but out of bonds of the pools given",
+					"is in use but out of bounds of the pools given",
 				),
 			)
 		}
@@ -164,27 +164,27 @@ func (webhook *IPPool) ValidateUpdate(_ context.Context, oldIPPool, newIPPool *i
 	return nil, apierrors.NewInvalid(ipamv1.GroupVersion.WithKind("IPPool").GroupKind(), newIPPool.Name, allErrs)
 }
 
-func (webhook *IPPool) checkPoolBonds(oldPool, newPool *ipamv1.IPPool) ([]ipamv1.IPAddressStr, []ipamv1.IPAddressStr) {
-	allocationOutOfBonds := []ipamv1.IPAddressStr{}
-	inUseOutOfBonds := []ipamv1.IPAddressStr{}
+func (webhook *IPPool) checkPoolBounds(oldPool, newPool *ipamv1.IPPool) ([]ipamv1.IPAddressStr, []ipamv1.IPAddressStr) {
+	allocationOutOfBounds := []ipamv1.IPAddressStr{}
+	inUseOutOfBounds := []ipamv1.IPAddressStr{}
 	for _, address := range newPool.Spec.PreAllocations {
-		inBonds := webhook.isAddressInBonds(newPool, address)
+		inBounds := webhook.isAddressInBounds(newPool, address)
 
-		if !inBonds {
-			allocationOutOfBonds = append(allocationOutOfBonds, address)
+		if !inBounds {
+			allocationOutOfBounds = append(allocationOutOfBounds, address)
 		}
 	}
 	for _, address := range oldPool.Status.Allocations {
-		inBonds := webhook.isAddressInBonds(newPool, address)
+		inBounds := webhook.isAddressInBounds(newPool, address)
 
-		if !inBonds {
-			inUseOutOfBonds = append(inUseOutOfBonds, address)
+		if !inBounds {
+			inUseOutOfBounds = append(inUseOutOfBounds, address)
 		}
 	}
-	return allocationOutOfBonds, inUseOutOfBonds
+	return allocationOutOfBounds, inUseOutOfBounds
 }
 
-func (webhook *IPPool) isAddressInBonds(newPool *ipamv1.IPPool, address ipamv1.IPAddressStr) bool {
+func (webhook *IPPool) isAddressInBounds(newPool *ipamv1.IPPool, address ipamv1.IPAddressStr) bool {
 	ip, err := netip.ParseAddr(string(address))
 	if err != nil {
 		return false

--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -518,8 +518,8 @@ func (m *IPPoolManager) allocateAddress(addressClaim *ipamv1.IPClaim,
 	// We have a preallocated IP but we did not find it in the pools! It means it is
 	// misconfigured
 	if !ipAllocated && ipPreAllocated {
-		addressClaim.Status.ErrorMessage = ptr.To("Pre-allocated IP out of bond")
-		return "", 0, nil, []ipamv1.IPAddressStr{}, errors.New("pre-allocated IP out of bond")
+		addressClaim.Status.ErrorMessage = ptr.To("Pre-allocated IP out of bounds")
+		return "", 0, nil, []ipamv1.IPAddressStr{}, errors.New("pre-allocated IP out of bounds")
 	}
 	if !ipAllocated {
 		addressClaim.Status.ErrorMessage = ptr.To("Exhausted IP Pools")
@@ -643,10 +643,10 @@ func (m *IPPoolManager) capiAllocateAddress(addressClaim *capipamv1.IPAddressCla
 			Status:             metav1.ConditionFalse,
 			LastTransitionTime: metav1.Now(),
 			Reason:             capipamv1.IPAddressClaimReadyAllocationFailedReason,
-			Message:            "Pre-allocated IP out of bond",
+			Message:            "Pre-allocated IP out of bounds",
 		})
 		addressClaim.SetConditions(conditions)
-		return "", 0, nil, errors.New("pre-allocated IP out of bond")
+		return "", 0, nil, errors.New("pre-allocated IP out of bounds")
 	}
 	if !ipAllocated {
 		conditions := make([]metav1.Condition, 0, 1)

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -2214,7 +2214,7 @@ var _ = Describe("IPPool manager", func() {
 			},
 			expectedPrefix: 26,
 		}),
-		Entry("One pool, pre-allocated, out of bonds", testCaseAllocateAddress{
+		Entry("One pool, pre-allocated, out of bounds", testCaseAllocateAddress{
 			ipPool: &ipamv1.IPPool{
 				Spec: ipamv1.IPPoolSpec{
 					Pools: []ipamv1.Pool{
@@ -2710,7 +2710,7 @@ var _ = Describe("IPPool manager", func() {
 			expectedGateway: (*ipamv1.IPAddressStr)(ptr.To("192.168.1.1")),
 			expectedPrefix:  26,
 		}),
-		Entry("One pool, pre-allocated, out of bonds", testCapiCaseAllocateAddress{
+		Entry("One pool, pre-allocated, out of bounds", testCapiCaseAllocateAddress{
 			ipPool: &ipamv1.IPPool{
 				Spec: ipamv1.IPPoolSpec{
 					Pools: []ipamv1.Pool{


### PR DESCRIPTION
<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**: checkPoolBonds → checkPoolBounds
isAddressInBonds → isAddressInBounds
allocationOutOfBonds → allocationOutOfBounds
inUseOutOfBonds → inUseOutOfBounds
inBonds → inBounds
"IP address out of bonds" → "IP address out of bounds" "IP address out of bonds for" → "IP address out of bounds for" "is out of bonds of the pools given" → "is out of bounds of the pools given" "is in use but out of bonds of the pools given" → "is in use but out of bounds of the pools given" "Pre-allocated IP out of bond" → "Pre-allocated IP out of bounds" "pre-allocated IP out of bond" → "pre-allocated IP out of bounds" "One pool, pre-allocated, out of bonds" → "One pool, pre-allocated, out of bounds"



<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
