### PR TITLE
🌱 Harden hack scripts agaist WORKDIR volume mount injection

### DIFF
--- a/hack/codegen.sh
+++ b/hack/codegen.sh
@@ -9,7 +9,6 @@ set -eux
 IS_CONTAINER="${IS_CONTAINER:-false}"
 ARTIFACTS="${ARTIFACTS:-/tmp}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME="/tmp/.cache"
@@ -35,9 +34,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/golang:1.26 \
-        "${WORKDIR}"/hack/codegen.sh "$@"
+        /workdir/hack/codegen.sh "$@"
 fi

--- a/hack/gomod.sh
+++ b/hack/gomod.sh
@@ -10,7 +10,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME=/tmp/.cache
@@ -41,9 +40,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/golang:1.26 \
-        "${WORKDIR}"/hack/gomod.sh "$@"
+        /workdir/hack/gomod.sh "$@"
 fi

--- a/hack/manifestlint.sh
+++ b/hack/manifestlint.sh
@@ -5,7 +5,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 K8S_VERSION="${K8S_VERSION:-master}"
 
 # --strict: Disallow additional properties not in schema.
@@ -32,9 +31,9 @@ else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --env KUBECONFORM_PATH="/" \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         ghcr.io/yannh/kubeconform:v0.6.7-alpine@sha256:824e0c248809e4b2da2a768b16b107cf17ada88a89ec6aa6050e566ba93ebbc6 \
-        "${WORKDIR}"/hack/manifestlint.sh "$@"
+        /workdir/hack/manifestlint.sh "$@"
 fi

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -6,7 +6,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 # all md files, but ignore .github
 if [ "${IS_CONTAINER}" != "false" ]; then
@@ -14,9 +13,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/pipelinecomponents/markdownlint-cli2:0.12.0@sha256:a3977fba9814f10d33a1d69ae607dc808e7a6470b2ba03e84c17193c0791aac0 \
-        "${WORKDIR}"/hack/markdownlint.sh "$@"
+        /workdir/hack/markdownlint.sh "$@"
 fi

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -5,7 +5,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     TOP_DIR="${1:-.}"
@@ -13,9 +12,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/koalaman/shellcheck-alpine:v0.10.0@sha256:5921d946dac740cbeec2fb1c898747b6105e585130cc7f0602eec9a10f7ddb63 \
-        "${WORKDIR}"/hack/shellcheck.sh "$@"
+        /workdir/hack/shellcheck.sh "$@"
 fi

--- a/hack/unit.sh
+++ b/hack/unit.sh
@@ -5,7 +5,6 @@ set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
-WORKDIR="${WORKDIR:-/workdir}"
 
 if [ "${IS_CONTAINER}" != "false" ]; then
     export XDG_CACHE_HOME=/tmp/.cache
@@ -19,9 +18,9 @@ if [ "${IS_CONTAINER}" != "false" ]; then
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
-        --volume "${PWD}:${WORKDIR}:ro,z" \
+        --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
-        --workdir "${WORKDIR}" \
+        --workdir /workdir \
         docker.io/golang:1.26 \
-        "${WORKDIR}"/hack/unit.sh "$@"
+        /workdir/hack/unit.sh "$@"
 fi


### PR DESCRIPTION
Affects the following scripts under /hack dir:
- codegen.sh
- gomod.sh
- unit.sh
- manifestlint.sh
- markdownlint.sh
- shellcheck.sh

This scripts read WORKDIR from then env and insert it directly into the conatiner's --volume mount specification. Becausee the volume spec is colon-bounded (`host:target:options`), a WORKDIR value cotaining a colon could alter how the mount is parsed.

This change removes the WORKDIR var and hardcodes the container path to /workdir, which matches the pattern already use in serveral other metal3 repos. Since /workdir was already the default there is no change in behavior for normal use, but the injection surface is eliminated.
