### PR TITLE
:seedling: Update image delimiter in kustomize patch commands to use '#' instead of '@'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,13 +280,13 @@ docker-build-%:
 .PHONY: set-manifest-image
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
-	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}:$(MANIFEST_TAG)"'\"@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's#image: .*#image: $(MANIFEST_IMG):$(MANIFEST_TAG)#' ./config/default/manager_image_patch.yaml
 
 .PHONY: set-manifest-image-digest
 set-manifest-image-digest:
 	$(info Updating kustomize image patch file for manager resource)
 	@if [ -z "$(MANIFEST_DIGEST)" ]; then echo "MANIFEST_DIGEST is not set"; exit 1; fi
-	sed -i'' -e 's@image: .*@image: \"'"${MANIFEST_IMG}@$(MANIFEST_DIGEST)"'\"@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's#image: .*#image: $(MANIFEST_IMG)@$(MANIFEST_DIGEST)#' ./config/default/manager_image_patch.yaml
 
 
 .PHONY: set-manifest-pull-policy


### PR DESCRIPTION
This should fix release process. Sed command now fails because delimiter is @ and image digest syntax contains that marker. Replace "@" with "#". I think we can also remove the `\"'"` safely. The environment variables are in single quotes and surrounded with `$()`.

<!-- Thank you for contributing to Metal3! -->

<!-- STEPS TO FOLLOW:
	1.  Add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones. The icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
	2. Add a description of the changes to **What this PR does / why we need it** section.
	3. Enter the issue number next to "Fixes #" below (if there is no tracking issue resolved, **remove that section**)
	4. Follow the steps in the checklist below
-->

**What this PR does / why we need it**:

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
