### PR TITLE
🌱Fix release notes generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ release-notes-tool:
 .PHONY: release-notes
 release-notes: $(RELEASE_NOTES_DIR) $(TOOLS_DIR)/go.mod ## Generates release notes for the given tag
 	@echo "Generating release notes for $(RELEASE_TAG)..."
-	@cd $(TOOLS_DIR) && $(GO) build -tags=tools -o $(BIN_DIR)/release ./release
+	@cd $(TOOLS_DIR) && go build -tags=tools -o $(BIN_DIR)/release ./release
 	@$(TOOLS_BIN_DIR)/release --releaseTag="$(RELEASE_TAG)" --githubToken="$${GITHUB_TOKEN}" > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 	@echo "Release notes written to $(realpath $(RELEASE_NOTES_DIR))/$(RELEASE_TAG).md"
 


### PR DESCRIPTION
This PR will fix the release-notes generation. We are facing the following error during running the make command

```
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later http://gnu.org/licenses/gpl.html
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

```
