### PR TITLE
:rocket: Release v1.14.0-rc.0

### DIFF
--- a/releasenotes/v1.14.0-rc.0.md
+++ b/releasenotes/v1.14.0-rc.0.md
@@ -1,0 +1,107 @@
+<!-- markdownlint-disable no-inline-html line-length -->
+# Changes since v1.13.0
+
+:rotating_light: This is a RELEASE CANDIDATE. Use it only for testing purposes.
+If you find any bugs, file an [issue](https://github.com/metal3-io/ip-address-manager/issues/new/).
+
+<details>
+<summary>More details about the release</summary>
+
+## :sparkles: New Features
+
+- Bump golang to v1.26 (#1478)
+- Add random IP allocation strategy to IPPool (#1359)
+
+## :bug: Bug Fixes
+
+- Fix IPv4 overflow detection (#1526)
+- Fix off-by-one in deleteOwnerRefFromList (#1506)
+- Reject empty pool entries in IPPool validation (#1524)
+- Fix propagate patch error in capiUpdateAddress (#1508)
+- Add uniqueness check for Preallocation at IPPool creation and validation times (#1439)
+- Validate IP requested through annotation is valid IP format (#1441)
+
+## :book: Documentation
+
+- Add a comment explaining anyErrorInExistingClaim checks Conditions[0] (#1525)
+- Update documentation and example configurations for IP Address Manager (#1426)
+- Update Api documentation (#1435)
+- Update compatibility matrix (#1409)
+- Update compatibility matrix (#1396)
+- Consolidate Metal3 Contributing guide in community repo (#1257)
+
+## :seedling: Others
+
+- Bump CAPI to 1.14.0 (#1548)
+- Fix release notes generation in Makefile (#1547)
+- Bump checkout action to v7 (#1546)
+- Bump the capi group across 2 directories with 3 updates (#1541)
+- Fix spelling by changing bond to bound (#1531)
+- Double quote all sh and make variables (#1449)
+- Require explicit GitHub token for release notes tool (#1494)
+- Remove --network=host from docker build targets (#1532)
+- Bump the capi group across 2 directories with 3 updates (#1536)
+- Update image delimiter in kustomize patch commands to use '#' instead of '@' (#1535)
+- Add checkPoolBonds to ValidateCreate (#1507)
+- Harden hack scripts agaist WORKDIR volume mount injection (#1533)
+- Bump CAPI to 1.14.0-beta.1 (#1523)
+- Bump the go_modules group across 1 directory with 2 updates (#1520)
+- Bump the github-actions group with 3 updates (#1522)
+- Add 'api'  to CAPI patterns in main dependabot configuration (#1501)
+- Bump the kubernetes group across 3 directories with 6 updates (#1510)
+- Bump the capi group across 2 directories with 2 updates (#1496)
+- Bump sigs.k8s.io/cluster-api/api from 1.14.0-alpha.0 to 1.14.0-beta.0 (#1497)
+- Bump go version to 1.26.5 (#1491)
+- Bump CAPI to v1.14.0-alpha.0, controller-runtime to v0.24.1 and k8s.io to v0.36.2 (#1490)
+- Bump the github-actions group with 3 updates (#1486)
+- Bump github.com/onsi/ginkgo/v2 from 2.31.0 to 2.32.0 in /api (#1482)
+- Bump github.com/onsi/ginkgo/v2 from 2.31.0 to 2.32.0 in /hack/tools (#1483)
+- Bump github.com/onsi/gomega from 1.42.0 to 1.42.1 in /api (#1481)
+- Add image build workflow for PR (#1471)
+- Bump CAPI to 1.13.3 (#1473)
+- Bump github.com/onsi/gomega from 1.41.0 to 1.42.0 in /api (#1463)
+- Bump github.com/onsi/ginkgo/v2 from 2.29.0 to 2.31.0 in /api (#1462)
+- Bump github.com/onsi/gomega from 1.41.0 to 1.42.0 in /test (#1466)
+- Bump github.com/onsi/ginkgo/v2 from 2.29.0 to 2.31.0 (#1461)
+- Bump the kubernetes group across 3 directories with 5 updates (#1459)
+- fix dependabots build and push workflop step (#1469)
+- Bump github.com/onsi/ginkgo/v2 from 2.30.0 to 2.31.0 in /test (#1465)
+- Bump github.com/onsi/ginkgo/v2 from 2.30.0 to 2.31.0 in /hack/tools (#1464)
+- Bump github.com/onsi/ginkgo/v2 from 2.29.0 to 2.30.0 in /test (#1454)
+- Remove git config modification from codegen.sh (#1457)
+- Bump the kubernetes group to v0.35.6 (#1450)
+- Bump github.com/onsi/ginkgo/v2 from 2.29.0 to 2.30.0 in /hack/tools (#1453)
+- Make codegen.sh mount host repo with ro (#1447)
+- Bump actions/checkout from 6.0.2 to 6.0.3 in the github-actions group across 1 directory (#1444)
+- Removed zizmor inline ignore (#1446)
+- Add image digest handling to release workflow and pin release artifact image with digest (#1438)
+- Set cooldown days to 3 for dependabot (#1443)
+- Bump x/net to v0.55.0 (#1434)
+- Bump actions/setup-go from 6.3.0 to 6.4.0 in the github-actions group (#1433)
+- Add e2e test for IPAM (#1410)
+- Bump Go version to 1.25.11 (#1430)
+- Bump the github-actions group with 2 updates (#1427)
+- Harden CI by removing unused script and updating setup-envtest to follow repo convention (#1425)
+- Bump github.com/onsi/gomega from 1.40.0 to 1.41.0 in /api (#1417)
+- Harden binary downloads in 3 scripts (#1423)
+- Bump github.com/onsi/ginkgo/v2 from 2.28.3 to 2.29.0 in /api (#1418)
+- Bump github.com/onsi/gomega from 1.40.0 to 1.41.0 (#1415)
+- Bump github.com/onsi/ginkgo/v2 from 2.28.3 to 2.29.0 (#1416)
+- Bump CAPI to v1.13.2 (#1414)
+- Bump the kubernetes group to v0.35.5 (#1413)
+- Bump sigs.k8s.io/cluster-api from 1.13.0 to 1.13.1 in the capi group across 1 directory (#1406)
+- Revert commits from release 1.13 (#1400)
+- Update dependabot config for release-1.13 (#1394)
+- Bump go version to 1.25.10 (#1398)
+- Add v1.14 metadata (#1392)
+- Bump the github-actions group across 1 directory with 4 updates (#1393)
+- remove obsoleted release action (#1389)
+- Bump github.com/onsi/ginkgo/v2 from 2.28.2 to 2.28.3 in /api (#1388)
+- Bump CAPI to v1.13.1 (#1384)
+- Bump github.com/onsi/ginkgo/v2 from 2.28.2 to 2.28.3 (#1385)
+
+</details>
+
+The container image for this release is: v1.14.0-rc.0
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
New rc release for IPAM v1.14.0-rc.0. 

:rotating_light: This is a RELEASE CANDIDATE. Use it only for testing purposes.
If you find any bugs, file an [issue](https://github.com/metal3-io/ip-address-manager/issues/new/).