### PR TITLE
🐛 Report IPAddress name collisions from duplicate namePrefix

### DIFF
--- a/ipam/ippool_manager.go
+++ b/ipam/ippool_manager.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
@@ -57,9 +58,10 @@ type IPPoolManagerInterface interface {
 
 // IPPoolManager is responsible for performing machine reconciliation.
 type IPPoolManager struct {
-	client client.Client
-	IPPool *ipamv1.IPPool
-	Log    logr.Logger
+	client   client.Client
+	IPPool   *ipamv1.IPPool
+	Log      logr.Logger
+	recorder events.EventRecorder
 }
 
 // NewIPPoolManager returns a new helper for managing a ipPool object.
@@ -755,13 +757,26 @@ func (m *IPPoolManager) createAddress(ctx context.Context,
 		},
 	}
 
-	// Create the IPAddress object. If we get a conflict (that will set
-	// Transient error), then requeue to retrigger the reconciliation with
-	// the new state
+	// Create the IPAddress object. On AlreadyExists, probe the existing
+	// object's owner: a different pool/claim is a terminal namePrefix
+	// collision (status set, no requeue); the same pool/claim is a stale-cache
+	// race and stays transient so we requeue.
 	if err := createObject(ctx, m.client, addressObject); err != nil {
 		var reconcileError ReconcileError
 		if !errors.As(err, &reconcileError) {
+			// Not the AlreadyExists case: surface the real error and requeue.
 			addressClaim.Status.ErrorMessage = ptr.To("Failed to create associated IPAddress object")
+			return addresses, err
+		}
+		// Name is taken. Probe the owner to tell a real collision from a
+		// benign stale-cache race.
+		if collision, poolName, claimName := m.checkNameCollision(ctx, &ipamv1.IPAddress{}, addressName, addressClaim.Name); collision {
+			msg := fmt.Sprintf("IPAddress name collision: %q already exists, owned by IPPool %q / IPClaim %q (likely a duplicate spec.namePrefix)", addressName, poolName, claimName)
+			addressClaim.Status.ErrorMessage = ptr.To(msg)
+			if m.recorder != nil {
+				m.recorder.Eventf(m.IPPool, nil, corev1.EventTypeWarning, "IPAddressNameCollision", "AllocateIPAddress", "%s", msg)
+			}
+			return addresses, WithTerminalError(errors.New(msg))
 		}
 		return addresses, err
 	}
@@ -861,12 +876,14 @@ func (m *IPPoolManager) capiCreateAddress(ctx context.Context,
 		},
 	}
 
-	// Create the IPAddress object. If we get a conflict (that will set
-	// Transient error), then requeue to retrigger the reconciliation with
-	// the new state
+	// Create the IPAddress object. On AlreadyExists, probe the existing
+	// object's owner: a different pool/claim is a terminal namePrefix
+	// collision (status set, no requeue); the same pool/claim is a stale-cache
+	// race and stays transient so we requeue.
 	if err := createObject(ctx, m.client, addressObject); err != nil {
 		var reconcileError ReconcileError
 		if !errors.As(err, &reconcileError) {
+			// Not the AlreadyExists case: surface the real error and requeue.
 			conditions := make([]metav1.Condition, 0, 1)
 			conditions = append(conditions, metav1.Condition{
 				Type:               capipamv1.IPAddressClaimReadyCondition,
@@ -876,6 +893,23 @@ func (m *IPPoolManager) capiCreateAddress(ctx context.Context,
 				Message:            "Failed to create associated IPAddress object",
 			})
 			addressClaim.SetConditions(conditions)
+			return addresses, err
+		}
+		// Name is taken. Probe the owner to tell a real collision from a
+		// benign stale-cache race.
+		if collision, poolName, claimName := m.checkNameCollision(ctx, &capipamv1.IPAddress{}, addressName, addressClaim.Name); collision {
+			msg := fmt.Sprintf("IPAddress name collision: %q already exists, owned by IPPool %q / IPClaim %q (likely a duplicate spec.namePrefix)", addressName, poolName, claimName)
+			addressClaim.SetConditions([]metav1.Condition{{
+				Type:               capipamv1.IPAddressClaimReadyCondition,
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             capipamv1.IPAddressClaimReadyAllocationFailedReason,
+				Message:            msg,
+			}})
+			if m.recorder != nil {
+				m.recorder.Eventf(m.IPPool, nil, corev1.EventTypeWarning, "IPAddressNameCollision", "AllocateIPAddress", "%s", msg)
+			}
+			return addresses, WithTerminalError(errors.New(msg))
 		}
 		return addresses, err
 	}
@@ -1069,4 +1103,40 @@ func anyErrorInExistingClaim(addressClaim capipamv1.IPAddressClaim) bool {
 	return len(addressClaim.Status.Conditions) > 0 &&
 		(addressClaim.Status.Conditions[0].Reason == capipamv1.IPAddressClaimReadyAllocationFailedReason ||
 			addressClaim.Status.Conditions[0].Reason == capipamv1.IPAddressClaimReadyPoolExhaustedReason)
+}
+
+// checkNameCollision returns true if an IPAddress with the given name already
+// exists but is NOT owned by this pool/claim (i.e. a namePrefix collision),
+// along with the owning pool and claim names for the error message.
+//
+// Pass an empty typed object (&ipamv1.IPAddress{} or &capipamv1.IPAddress{})
+// so the same Get + comparison logic serves both APIs; only the owner-ref
+// field paths differ between the two IPAddress types.
+func (m *IPPoolManager) checkNameCollision(ctx context.Context, existing client.Object, name, claimName string) (bool, string, string) {
+	key := client.ObjectKey{Name: name, Namespace: m.IPPool.Namespace}
+	if err := m.client.Get(ctx, key, existing); err != nil {
+		return false, "", ""
+	}
+	// Terminating object: the name will free up, so requeue rather than
+	// fail terminally.
+	if existing.GetDeletionTimestamp() != nil {
+		return false, "", ""
+	}
+
+	var ownerPool, ownerClaim string
+	switch e := existing.(type) {
+	case *ipamv1.IPAddress:
+		ownerPool, ownerClaim = e.Spec.Pool.Name, e.Spec.Claim.Name
+	case *capipamv1.IPAddress:
+		ownerPool, ownerClaim = e.Spec.PoolRef.Name, e.Spec.ClaimRef.Name
+	default:
+		// Unknown type: can't determine ownership, so don't claim a collision.
+		return false, "", ""
+	}
+
+	// Benign only if this exact pool+claim already owns the address (stale-cache race).
+	if ownerPool == m.IPPool.Name && ownerClaim == claimName {
+		return false, "", ""
+	}
+	return true, ownerPool, ownerClaim
 }

--- a/ipam/ippool_manager_test.go
+++ b/ipam/ippool_manager_test.go
@@ -19,6 +19,7 @@ package ipam
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -28,12 +29,15 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	capipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var (
@@ -3609,4 +3613,383 @@ var _ = Describe("IPPool manager", func() {
 		})
 	})
 
+})
+
+var _ = Describe("IPAddress name collision (duplicate namePrefix)", func() {
+	const (
+		ns          = "myns"
+		collidingIP = "192.168.1.10"
+		// namePrefix "a-prefix" + IP -> "a-prefix-192-168-1-10"
+		collidingName = "a-prefix-192-168-1-10"
+	)
+
+	// newPool builds an IPPool named poolName whose namePrefix is "a-prefix"
+	// and whose single-address pool only contains collidingIP.
+	newPool := func(poolName string) *ipamv1.IPPool {
+		start := ipamv1.IPAddressStr(collidingIP)
+		return &ipamv1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      poolName,
+				Namespace: ns,
+			},
+			Spec: ipamv1.IPPoolSpec{
+				NamePrefix: "a-prefix",
+				Pools: []ipamv1.Pool{
+					{
+						Start:  &start,
+						End:    &start,
+						Prefix: 24,
+					},
+				},
+			},
+			Status: ipamv1.IPPoolStatus{
+				Allocations: map[string]ipamv1.IPAddressStr{},
+			},
+		}
+	}
+
+	Context("metal3 IPClaim path", func() {
+		It("sets a terminal error when the IPAddress name is owned by a different pool/claim", func() {
+			// Pre-existing IPAddress owned by a DIFFERENT pool/claim.
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-a"},
+					Claim:   corev1.ObjectReference{Name: "a-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTerminal()).To(BeTrue())
+
+			Expect(claim.Status.ErrorMessage).NotTo(BeNil())
+			Expect(*claim.Status.ErrorMessage).To(ContainSubstring("collision"))
+		})
+
+		It("does not set an error for a benign race (address owned by this pool/claim)", func() {
+			// Pre-existing IPAddress owned by THIS pool/claim (stale-cache race).
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-b"},
+					Claim:   corev1.ObjectReference{Name: "b-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			// AlreadyExists is still surfaced as a transient error, but no
+			// terminal collision error message is set on the claim.
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTransient()).To(BeTrue())
+			Expect(claim.Status.ErrorMessage).To(BeNil())
+		})
+
+		It("emits a Warning event on the IPPool when a collision occurs", func() {
+			// Pre-existing IPAddress owned by a DIFFERENT pool/claim.
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-a"},
+					Claim:   corev1.ObjectReference{Name: "a-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			// Build the manager through the factory so the EventRecorder is wired.
+			recorder := events.NewFakeRecorder(10)
+			mgrIface, err := NewManagerFactory(fakeClient, WithEventRecorder(recorder)).NewIPPoolManager(newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			ipPoolMgr, ok := mgrIface.(*IPPoolManager)
+			Expect(ok).To(BeTrue())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+			Eventually(recorder.Events).Should(Receive(ContainSubstring("IPAddressNameCollision")))
+		})
+
+		It("treats same-pool but different-claim ownership as a collision", func() {
+			// Same pool owns the name, but for a DIFFERENT claim than the one
+			// being reconciled. This must be a terminal collision, not a benign race.
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-b"},
+					Claim:   corev1.ObjectReference{Name: "other-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTerminal()).To(BeTrue())
+			Expect(claim.Status.ErrorMessage).NotTo(BeNil())
+			Expect(*claim.Status.ErrorMessage).To(ContainSubstring("collision"))
+		})
+
+		It("stays transient (no terminal collision) when the existing address is terminating", func() {
+			// Terminating foreign object: Create returns AlreadyExists until it
+			// clears, so this must requeue rather than fail terminally.
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              collidingName,
+					Namespace:         ns,
+					DeletionTimestamp: &timeNow,
+					Finalizers:        []string{ipamv1.IPAddressFinalizer},
+				},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-a"},
+					Claim:   corev1.ObjectReference{Name: "a-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTransient()).To(BeTrue())
+			Expect(claim.Status.ErrorMessage).To(BeNil())
+		})
+
+		It("surfaces a non-transient create error without diagnosing a collision", func() {
+			// Create fails for a non-AlreadyExists reason: surface it and
+			// requeue, don't mask it as a terminal collision.
+			existing := &ipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: ipamv1.IPAddressSpec{
+					Address: ipamv1.IPAddressStr(collidingIP),
+					Pool:    corev1.ObjectReference{Name: "ippool-a"},
+					Claim:   corev1.ObjectReference{Name: "a-claim"},
+				},
+			}
+			claim := &ipamv1.IPClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: ipamv1.IPClaimSpec{
+					Pool: corev1.ObjectReference{Name: "ippool-b", Namespace: ns},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+						return apierrors.NewBadRequest("boom")
+					},
+				}).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.createAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeFalse())
+
+			Expect(claim.Status.ErrorMessage).NotTo(BeNil())
+			Expect(*claim.Status.ErrorMessage).NotTo(ContainSubstring("collision"))
+		})
+	})
+
+	Context("CAPI IPAddressClaim path", func() {
+		It("sets an AllocationFailed condition when the IPAddress name is owned by a different pool/claim", func() {
+			existing := &capipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: capipamv1.IPAddressSpec{
+					Address:  collidingIP,
+					PoolRef:  capipamv1.IPPoolReference{Name: "ippool-a"},
+					ClaimRef: capipamv1.IPAddressClaimReference{Name: "a-claim"},
+				},
+			}
+			claim := &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: capipamv1.IPAddressClaimSpec{
+					PoolRef: capipamv1.IPPoolReference{Name: "ippool-b"},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.capiCreateAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTerminal()).To(BeTrue())
+
+			Expect(claim.Status.Conditions).NotTo(BeEmpty())
+			Expect(claim.Status.Conditions[0].Reason).To(Equal(capipamv1.IPAddressClaimReadyAllocationFailedReason))
+			Expect(claim.Status.Conditions[0].Message).To(ContainSubstring("collision"))
+		})
+
+		It("stays transient (no terminal collision) when the existing address is terminating", func() {
+			// Terminating foreign object: Create returns AlreadyExists until it
+			// clears, so this must requeue rather than fail terminally.
+			existing := &capipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              collidingName,
+					Namespace:         ns,
+					DeletionTimestamp: &timeNow,
+					Finalizers:        []string{IPAddressFinalizer},
+				},
+				Spec: capipamv1.IPAddressSpec{
+					Address:  collidingIP,
+					PoolRef:  capipamv1.IPPoolReference{Name: "ippool-a"},
+					ClaimRef: capipamv1.IPAddressClaimReference{Name: "a-claim"},
+				},
+			}
+			claim := &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: capipamv1.IPAddressClaimSpec{
+					PoolRef: capipamv1.IPPoolReference{Name: "ippool-b"},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.capiCreateAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeTrue())
+			Expect(reconcileError.IsTransient()).To(BeTrue())
+			Expect(claim.Status.Conditions).To(BeEmpty())
+		})
+
+		It("surfaces a non-transient create error without diagnosing a collision", func() {
+			// Create fails for a non-AlreadyExists reason: surface it and
+			// requeue, don't mask it as a terminal collision.
+			existing := &capipamv1.IPAddress{
+				ObjectMeta: metav1.ObjectMeta{Name: collidingName, Namespace: ns},
+				Spec: capipamv1.IPAddressSpec{
+					Address:  collidingIP,
+					PoolRef:  capipamv1.IPPoolReference{Name: "ippool-a"},
+					ClaimRef: capipamv1.IPAddressClaimReference{Name: "a-claim"},
+				},
+			}
+			claim := &capipamv1.IPAddressClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "b-claim", Namespace: ns},
+				Spec: capipamv1.IPAddressClaimSpec{
+					PoolRef: capipamv1.IPPoolReference{Name: "ippool-b"},
+				},
+			}
+
+			fakeClient := fakeclient.NewClientBuilder().
+				WithScheme(setupScheme()).
+				WithObjects(existing).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+						return apierrors.NewBadRequest("boom")
+					},
+				}).
+				Build()
+
+			ipPoolMgr, err := NewIPPoolManager(fakeClient, newPool("ippool-b"), logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = ipPoolMgr.capiCreateAddress(context.Background(), claim, map[ipamv1.IPAddressStr]string{})
+			Expect(err).To(HaveOccurred())
+
+			var reconcileError ReconcileError
+			Expect(errors.As(err, &reconcileError)).To(BeFalse())
+
+			Expect(claim.Status.Conditions).NotTo(BeEmpty())
+			Expect(claim.Status.Conditions[0].Message).NotTo(ContainSubstring("collision"))
+		})
+	})
 })

--- a/ipam/manager_factory.go
+++ b/ipam/manager_factory.go
@@ -19,6 +19,7 @@ package ipam
 import (
 	"github.com/go-logr/logr"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,15 +31,34 @@ type ManagerFactoryInterface interface {
 
 // ManagerFactory only contains a client.
 type ManagerFactory struct {
-	client client.Client
+	client   client.Client
+	recorder events.EventRecorder
 }
 
-// NewManagerFactory returns a new factory.
-func NewManagerFactory(client client.Client) ManagerFactory {
-	return ManagerFactory{client: client}
+// ManagerFactoryOption configures a ManagerFactory.
+type ManagerFactoryOption func(*ManagerFactory)
+
+// WithEventRecorder sets the event recorder used to emit events on IPPool objects.
+func WithEventRecorder(recorder events.EventRecorder) ManagerFactoryOption {
+	return func(f *ManagerFactory) { f.recorder = recorder }
+}
+
+// NewManagerFactory returns a new factory. Optional configuration such as an
+// event recorder can be supplied via ManagerFactoryOption.
+func NewManagerFactory(client client.Client, opts ...ManagerFactoryOption) ManagerFactory {
+	f := ManagerFactory{client: client}
+	for _, opt := range opts {
+		opt(&f)
+	}
+	return f
 }
 
 // NewIPPoolManager creates a new IPPoolManager.
 func (f ManagerFactory) NewIPPoolManager(ipPool *ipamv1.IPPool, metadataLog logr.Logger) (IPPoolManagerInterface, error) {
-	return NewIPPoolManager(f.client, ipPool, metadataLog)
+	mgr, err := NewIPPoolManager(f.client, ipPool, metadataLog)
+	if err != nil {
+		return nil, err
+	}
+	mgr.recorder = f.recorder
+	return mgr, nil
 }

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func setupChecks(mgr ctrl.Manager) {
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&controllers.IPPoolReconciler{
 		Client:           mgr.GetClient(),
-		ManagerFactory:   ipam.NewManagerFactory(mgr.GetClient()),
+		ManagerFactory:   ipam.NewManagerFactory(mgr.GetClient(), ipam.WithEventRecorder(mgr.GetEventRecorder("metal3-ippool-controller"))),
 		Log:              ctrl.Log.WithName("controllers").WithName("IPPoolForIPClaim"),
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManagerForIPClaim(ctx, mgr, concurrency(ippoolConcurrency)); err != nil {
@@ -219,7 +219,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if err := (&controllers.IPPoolReconciler{
 		Client:           mgr.GetClient(),
-		ManagerFactory:   ipam.NewManagerFactory(mgr.GetClient()),
+		ManagerFactory:   ipam.NewManagerFactory(mgr.GetClient(), ipam.WithEventRecorder(mgr.GetEventRecorder("metal3-ippool-controller-capi"))),
 		Log:              ctrl.Log.WithName("controllers").WithName("IPPoolForIPAddressClaim"),
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManagerForIPAddressClaim(ctx, mgr, concurrency(ippoolConcurrency)); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When two IPPools in the same namespace share a `spec.namePrefix` and their address ranges overlap, they generate identical IPAddress object names. The second claim's IPAddress creation fail with `AlreadyExist`, which `createObject` converts into a transient error. As a result no status was set on the claim, no event was emitted, and the controller requeued indefinitely, a silent failure that is hard to diagnose.

This change makes the failure observable and stops the requeued loop, without changing the naming scheme.

**Changes**:

- On IPAddress create failure, probe the existing object's owner:
  - Owned by a *different* pool/claim -> treat as a terminal collision.
  - Owned by *this* pool/claim (stale-cache race) -> keep the existing transient/requeue behavior.
- Surface the collision on both objects:
  - IPClaim: `Status.ErrorMessage` (Metal3) / `AllocationFailed` condition (CAPI). Setting these also stops the reconcile loop from re-processing the claim.
  - IPPool: a `Warning` `IPAddressNameCollision` event, via a new `EventRecorder` wired through the manager factory.
- Unit test for the metal3 collision, metal3 benign race, CAPI collision, and the IPPool event emission.

No CRD/RBAC changes and no mock regeneration were needed as events RBAC already existed and the `ManagerFactoryInterface` signature is unchaged.

**NOTE**: this does not let the same `namePrefix` pool with overlapping ranges coexist, the collision claim still gets no address, it just fails loudly with an actionable message. Enabling coexistence requires a bigger change to the IPAddress naming scheme and should be discuss in another issue.

Fixes #1437

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
