### PR TITLE
🌱Add id-token permission to build-images-pr workflow

### DIFF
--- a/.github/workflows/build-images-pr.yml
+++ b/.github/workflows/build-images-pr.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository == 'metal3-io/ip-address-manager'
     permissions:
       contents: read
+      id-token: write
     uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
     with:
       image-name: 'ip-address-manager'


### PR DESCRIPTION
https://github.com/metal3-io/cluster-api-provider-metal3/issues/3701
Add id-token to fix the workflow